### PR TITLE
Add SQLUI layout schema repository skeleton

### DIFF
--- a/Plugins/SQLUI/Source/SQLUICore/Private/Layout/SQLUILayoutJson.cpp
+++ b/Plugins/SQLUI/Source/SQLUICore/Private/Layout/SQLUILayoutJson.cpp
@@ -1,0 +1,194 @@
+#include "Layout/SQLUILayoutJson.h"
+
+#include "JsonObjectConverter.h"
+
+namespace
+{
+void AddSQLUILayoutValidationError(FSQLUILayoutValidationResult& Result, const FString& ErrorMessage)
+{
+	Result.bIsValid = false;
+	Result.Errors.Add(ErrorMessage);
+}
+
+void AddSQLUILayoutValidationWarning(FSQLUILayoutValidationResult& Result, const FString& WarningMessage)
+{
+	Result.Warnings.Add(WarningMessage);
+}
+}
+
+bool FSQLUILayoutJson::ToJsonString(
+	const FSQLUILayoutDocument& Document,
+	FString& OutJson,
+	FSQLUILayoutValidationResult& OutValidation)
+{
+	OutJson.Empty();
+	OutValidation = ValidateDocument(Document);
+	if (!OutValidation.bIsValid)
+	{
+		return false;
+	}
+
+	const bool bSerialized = FJsonObjectConverter::UStructToJsonObjectString(
+		FSQLUILayoutDocument::StaticStruct(),
+		&Document,
+		OutJson,
+		0,
+		0);
+
+	if (!bSerialized)
+	{
+		AddSQLUILayoutValidationError(OutValidation, TEXT("Failed to serialize SQLUI layout document to JSON."));
+	}
+
+	return bSerialized && OutValidation.bIsValid;
+}
+
+bool FSQLUILayoutJson::FromJsonString(
+	const FString& Json,
+	FSQLUILayoutDocument& OutDocument,
+	FSQLUILayoutValidationResult& OutValidation)
+{
+	OutDocument = FSQLUILayoutDocument();
+	OutValidation = FSQLUILayoutValidationResult();
+
+	if (Json.IsEmpty())
+	{
+		AddSQLUILayoutValidationError(OutValidation, TEXT("Cannot deserialize an empty SQLUI layout JSON string."));
+		return false;
+	}
+
+	const bool bDeserialized = FJsonObjectConverter::JsonObjectStringToUStruct(
+		Json,
+		&OutDocument,
+		0,
+		0);
+
+	if (!bDeserialized)
+	{
+		AddSQLUILayoutValidationError(OutValidation, TEXT("Failed to deserialize SQLUI layout JSON string."));
+		return false;
+	}
+
+	OutValidation = ValidateDocument(OutDocument);
+	return OutValidation.bIsValid;
+}
+
+FSQLUILayoutValidationResult FSQLUILayoutJson::ValidateDocument(const FSQLUILayoutDocument& Document)
+{
+	FSQLUILayoutValidationResult Result;
+
+	if (Document.Version.SchemaVersion <= 0)
+	{
+		AddSQLUILayoutValidationError(Result, TEXT("SQLUI layout schema version must be greater than zero."));
+	}
+
+	if (Document.Version.Revision <= 0)
+	{
+		AddSQLUILayoutValidationError(Result, TEXT("SQLUI layout revision must be greater than zero."));
+	}
+
+	if (Document.Metadata.LayoutId.IsEmpty())
+	{
+		AddSQLUILayoutValidationError(Result, TEXT("SQLUI layout metadata must include a layout id."));
+	}
+
+	if (Document.RootWidgetId.IsEmpty())
+	{
+		AddSQLUILayoutValidationError(Result, TEXT("SQLUI layout document must include a root widget id."));
+	}
+
+	if (Document.Nodes.IsEmpty())
+	{
+		AddSQLUILayoutValidationError(Result, TEXT("SQLUI layout document must include at least one widget node."));
+	}
+
+	TMap<FString, const FSQLUILayoutNode*> NodesById;
+	for (const FSQLUILayoutNode& Node : Document.Nodes)
+	{
+		if (Node.WidgetId.IsEmpty())
+		{
+			AddSQLUILayoutValidationError(Result, TEXT("SQLUI layout node must include a widget id."));
+			continue;
+		}
+
+		if (NodesById.Contains(Node.WidgetId))
+		{
+			AddSQLUILayoutValidationError(Result, FString::Printf(TEXT("SQLUI layout node id '%s' is duplicated."), *Node.WidgetId));
+		}
+		else
+		{
+			NodesById.Add(Node.WidgetId, &Node);
+		}
+
+		if (Node.WidgetTypeKey.IsEmpty())
+		{
+			AddSQLUILayoutValidationError(Result, FString::Printf(TEXT("SQLUI layout node '%s' must include a widget type key."), *Node.WidgetId));
+		}
+	}
+
+	if (!Document.RootWidgetId.IsEmpty() && !NodesById.Contains(Document.RootWidgetId))
+	{
+		AddSQLUILayoutValidationError(Result, FString::Printf(TEXT("SQLUI layout root widget id '%s' does not match any node."), *Document.RootWidgetId));
+	}
+
+	for (const FSQLUILayoutNode& Node : Document.Nodes)
+	{
+		if (Node.WidgetId.IsEmpty())
+		{
+			continue;
+		}
+
+		if (!Node.ParentWidgetId.IsEmpty())
+		{
+			const FSQLUILayoutNode* const* ParentNode = NodesById.Find(Node.ParentWidgetId);
+			if (!ParentNode)
+			{
+				AddSQLUILayoutValidationError(Result, FString::Printf(TEXT("SQLUI layout node '%s' references missing parent '%s'."), *Node.WidgetId, *Node.ParentWidgetId));
+			}
+			else if (!(*ParentNode)->ChildWidgetIds.Contains(Node.WidgetId))
+			{
+				AddSQLUILayoutValidationWarning(Result, FString::Printf(TEXT("SQLUI layout parent '%s' does not list child '%s'."), *Node.ParentWidgetId, *Node.WidgetId));
+			}
+		}
+
+		TSet<FString> SeenChildIds;
+		for (const FString& ChildWidgetId : Node.ChildWidgetIds)
+		{
+			if (ChildWidgetId.IsEmpty())
+			{
+				AddSQLUILayoutValidationError(Result, FString::Printf(TEXT("SQLUI layout node '%s' contains an empty child widget id."), *Node.WidgetId));
+				continue;
+			}
+
+			if (ChildWidgetId == Node.WidgetId)
+			{
+				AddSQLUILayoutValidationError(Result, FString::Printf(TEXT("SQLUI layout node '%s' cannot be its own child."), *Node.WidgetId));
+			}
+
+			if (SeenChildIds.Contains(ChildWidgetId))
+			{
+				AddSQLUILayoutValidationError(Result, FString::Printf(TEXT("SQLUI layout node '%s' lists child '%s' more than once."), *Node.WidgetId, *ChildWidgetId));
+			}
+			else
+			{
+				SeenChildIds.Add(ChildWidgetId);
+			}
+
+			const FSQLUILayoutNode* const* ChildNode = NodesById.Find(ChildWidgetId);
+			if (!ChildNode)
+			{
+				AddSQLUILayoutValidationError(Result, FString::Printf(TEXT("SQLUI layout node '%s' references missing child '%s'."), *Node.WidgetId, *ChildWidgetId));
+			}
+			else if (!(*ChildNode)->ParentWidgetId.IsEmpty() && (*ChildNode)->ParentWidgetId != Node.WidgetId)
+			{
+				AddSQLUILayoutValidationError(Result, FString::Printf(TEXT("SQLUI layout node '%s' lists child '%s', but that child references parent '%s'."), *Node.WidgetId, *ChildWidgetId, *(*ChildNode)->ParentWidgetId));
+			}
+			else if ((*ChildNode)->ParentWidgetId.IsEmpty())
+			{
+				AddSQLUILayoutValidationWarning(Result, FString::Printf(TEXT("SQLUI layout child '%s' does not reference parent '%s'."), *ChildWidgetId, *Node.WidgetId));
+			}
+		}
+	}
+
+	return Result;
+}

--- a/Plugins/SQLUI/Source/SQLUICore/Private/Layout/SQLUILayoutRepository.cpp
+++ b/Plugins/SQLUI/Source/SQLUICore/Private/Layout/SQLUILayoutRepository.cpp
@@ -1,0 +1,36 @@
+#include "Layout/SQLUILayoutRepository.h"
+
+namespace
+{
+const TCHAR* SQLUILayoutRepositoryUnavailableMessage = TEXT("No concrete SQLUI layout repository backend is implemented yet.");
+}
+
+void USQLUILayoutRepository::LoadLayout(const FString& LayoutId, FSQLUILayoutLoadCompleteDelegate Callback)
+{
+	Callback.ExecuteIfBound(MakeBackendUnavailableLoadResult(LayoutId));
+}
+
+void USQLUILayoutRepository::SaveLayout(const FSQLUILayoutDocument& Document, FSQLUILayoutSaveCompleteDelegate Callback)
+{
+	Callback.ExecuteIfBound(MakeBackendUnavailableSaveResult(Document));
+}
+
+FSQLUILayoutLoadResult USQLUILayoutRepository::MakeBackendUnavailableLoadResult(const FString& LayoutId)
+{
+	FSQLUILayoutLoadResult Result;
+	Result.bSucceeded = false;
+	Result.bBackendUnavailable = true;
+	Result.ErrorMessage = SQLUILayoutRepositoryUnavailableMessage;
+	Result.Document.Metadata.LayoutId = LayoutId;
+	return Result;
+}
+
+FSQLUILayoutSaveResult USQLUILayoutRepository::MakeBackendUnavailableSaveResult(const FSQLUILayoutDocument& Document)
+{
+	FSQLUILayoutSaveResult Result;
+	Result.bSucceeded = false;
+	Result.bBackendUnavailable = true;
+	Result.ErrorMessage = SQLUILayoutRepositoryUnavailableMessage;
+	Result.SavedLayoutId = Document.Metadata.LayoutId;
+	return Result;
+}

--- a/Plugins/SQLUI/Source/SQLUICore/Public/Layout/ISQLUILayoutRepository.h
+++ b/Plugins/SQLUI/Source/SQLUICore/Public/Layout/ISQLUILayoutRepository.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Layout/SQLUILayoutTypes.h"
+
+DECLARE_DELEGATE_OneParam(FSQLUILayoutLoadCompleteDelegate, const FSQLUILayoutLoadResult&);
+DECLARE_DELEGATE_OneParam(FSQLUILayoutSaveCompleteDelegate, const FSQLUILayoutSaveResult&);
+
+class SQLUICORE_API ISQLUILayoutRepository
+{
+public:
+	virtual ~ISQLUILayoutRepository() = default;
+
+	virtual void LoadLayout(const FString& LayoutId, FSQLUILayoutLoadCompleteDelegate Callback) = 0;
+	virtual void SaveLayout(const FSQLUILayoutDocument& Document, FSQLUILayoutSaveCompleteDelegate Callback) = 0;
+};

--- a/Plugins/SQLUI/Source/SQLUICore/Public/Layout/SQLUILayoutJson.h
+++ b/Plugins/SQLUI/Source/SQLUICore/Public/Layout/SQLUILayoutJson.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Layout/SQLUILayoutTypes.h"
+
+class SQLUICORE_API FSQLUILayoutJson
+{
+public:
+	static bool ToJsonString(
+		const FSQLUILayoutDocument& Document,
+		FString& OutJson,
+		FSQLUILayoutValidationResult& OutValidation);
+
+	static bool FromJsonString(
+		const FString& Json,
+		FSQLUILayoutDocument& OutDocument,
+		FSQLUILayoutValidationResult& OutValidation);
+
+	static FSQLUILayoutValidationResult ValidateDocument(const FSQLUILayoutDocument& Document);
+};

--- a/Plugins/SQLUI/Source/SQLUICore/Public/Layout/SQLUILayoutRepository.h
+++ b/Plugins/SQLUI/Source/SQLUICore/Public/Layout/SQLUILayoutRepository.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Layout/ISQLUILayoutRepository.h"
+#include "UObject/Object.h"
+
+#include "SQLUILayoutRepository.generated.h"
+
+UCLASS(BlueprintType)
+class SQLUICORE_API USQLUILayoutRepository : public UObject, public ISQLUILayoutRepository
+{
+	GENERATED_BODY()
+
+public:
+	virtual void LoadLayout(const FString& LayoutId, FSQLUILayoutLoadCompleteDelegate Callback) override;
+	virtual void SaveLayout(const FSQLUILayoutDocument& Document, FSQLUILayoutSaveCompleteDelegate Callback) override;
+
+protected:
+	static FSQLUILayoutLoadResult MakeBackendUnavailableLoadResult(const FString& LayoutId);
+	static FSQLUILayoutSaveResult MakeBackendUnavailableSaveResult(const FSQLUILayoutDocument& Document);
+};

--- a/Plugins/SQLUI/Source/SQLUICore/Public/Layout/SQLUILayoutTypes.h
+++ b/Plugins/SQLUI/Source/SQLUICore/Public/Layout/SQLUILayoutTypes.h
@@ -1,0 +1,203 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+#include "SQLUILayoutTypes.generated.h"
+
+USTRUCT(BlueprintType)
+struct SQLUICORE_API FSQLUILayoutVersion
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	int32 SchemaVersion = 1;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	int32 Revision = 1;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FString Label;
+};
+
+USTRUCT(BlueprintType)
+struct SQLUICORE_API FSQLUILayoutMetadata
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FString LayoutId;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FString DisplayName;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FString Description;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FString CreatedBy;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FString CreatedAtUtc;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FString UpdatedAtUtc;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	TArray<FString> Tags;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	TMap<FString, FString> SearchMetadata;
+};
+
+USTRUCT(BlueprintType)
+struct SQLUICORE_API FSQLUILayoutBinding
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FString BindingId;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FString TargetProperty;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FString SourceKey;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FString SourcePath;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FString TransformKey;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	TMap<FString, FString> Options;
+};
+
+USTRUCT(BlueprintType)
+struct SQLUICORE_API FSQLUILayoutAction
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FString ActionId;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FString Trigger;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FString ActionTypeKey;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	TMap<FString, FString> Parameters;
+};
+
+USTRUCT(BlueprintType)
+struct SQLUICORE_API FSQLUILayoutNode
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FString WidgetId;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FString ParentWidgetId;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FString WidgetTypeKey;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	TArray<FString> ChildWidgetIds;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	TMap<FString, FString> Properties;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	TArray<FSQLUILayoutBinding> Bindings;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	TArray<FSQLUILayoutAction> Actions;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	TArray<FString> Tags;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	TMap<FString, FString> SearchMetadata;
+};
+
+USTRUCT(BlueprintType)
+struct SQLUICORE_API FSQLUILayoutDocument
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FSQLUILayoutVersion Version;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FSQLUILayoutMetadata Metadata;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FString RootWidgetId;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	TArray<FSQLUILayoutNode> Nodes;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	TMap<FString, FString> Properties;
+};
+
+USTRUCT(BlueprintType)
+struct SQLUICORE_API FSQLUILayoutValidationResult
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	bool bIsValid = true;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	TArray<FString> Errors;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	TArray<FString> Warnings;
+};
+
+USTRUCT(BlueprintType)
+struct SQLUICORE_API FSQLUILayoutLoadResult
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	bool bSucceeded = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	bool bBackendUnavailable = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FString ErrorMessage;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FSQLUILayoutDocument Document;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FSQLUILayoutValidationResult Validation;
+};
+
+USTRUCT(BlueprintType)
+struct SQLUICORE_API FSQLUILayoutSaveResult
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	bool bSucceeded = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	bool bBackendUnavailable = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FString ErrorMessage;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FString SavedLayoutId;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout")
+	FSQLUILayoutValidationResult Validation;
+};

--- a/Plugins/SQLUI/Source/SQLUICore/SQLUICore.Build.cs
+++ b/Plugins/SQLUI/Source/SQLUICore/SQLUICore.Build.cs
@@ -12,5 +12,11 @@ public class SQLUICore : ModuleRules
 			"CoreUObject",
 			"Engine"
 		});
+
+		PrivateDependencyModuleNames.AddRange(new string[]
+		{
+			"Json",
+			"JsonUtilities"
+		});
 	}
 }


### PR DESCRIPTION
Summary
- Added SQLUI layout document/schema types
- Added layout metadata, version, node, binding, action, and validation types
- Added JSON serialization/deserialization helpers
- Added layout repository interface and skeleton implementation

Validation
- Ran git diff --check
- Built JerryRiggedEditor Win64 Development successfully

Notes
- No concrete SQLite backend yet
- No runtime widget creation yet
- No host-game logic
- Work is limited to SQLUICore