### PR TITLE
Add SQLUI widget catalog and layout factory skeleton

### DIFF
--- a/Plugins/SQLUI/Source/SQLUICore/Private/Layout/SQLUILayoutFactory.cpp
+++ b/Plugins/SQLUI/Source/SQLUICore/Private/Layout/SQLUILayoutFactory.cpp
@@ -1,0 +1,44 @@
+#include "Layout/SQLUILayoutFactory.h"
+
+#include "Layout/SQLUILayoutJson.h"
+
+namespace
+{
+void AddSQLUILayoutFactoryCatalogError(FSQLUIWidgetCatalogValidationResult& Result, const FString& ErrorMessage)
+{
+	Result.bIsValid = false;
+	Result.Errors.Add(ErrorMessage);
+}
+}
+
+FSQLUILayoutFactoryResult USQLUILayoutFactory::PrepareLayout(const FSQLUILayoutFactoryRequest& Request) const
+{
+	FSQLUILayoutFactoryResult Result;
+	Result.PreparedDocument = Request.Document;
+	Result.LayoutValidation = FSQLUILayoutJson::ValidateDocument(Request.Document);
+
+	if (!Result.LayoutValidation.bIsValid)
+	{
+		Result.ErrorMessage = TEXT("SQLUI layout factory could not prepare an invalid layout document.");
+		return Result;
+	}
+
+	if (!Request.WidgetCatalog)
+	{
+		AddSQLUILayoutFactoryCatalogError(
+			Result.CatalogValidation,
+			TEXT("SQLUI layout factory requires a widget catalog before preparing a layout."));
+		Result.ErrorMessage = TEXT("SQLUI layout factory could not prepare a layout without a widget catalog.");
+		return Result;
+	}
+
+	Result.CatalogValidation = Request.WidgetCatalog->ValidateLayoutDocument(Request.Document);
+	if (!Result.CatalogValidation.bIsValid)
+	{
+		Result.ErrorMessage = TEXT("SQLUI layout factory could not prepare a layout that failed widget catalog validation.");
+		return Result;
+	}
+
+	Result.bSucceeded = true;
+	return Result;
+}

--- a/Plugins/SQLUI/Source/SQLUICore/Private/WidgetCatalog/SQLUIWidgetCatalog.cpp
+++ b/Plugins/SQLUI/Source/SQLUICore/Private/WidgetCatalog/SQLUIWidgetCatalog.cpp
@@ -1,0 +1,250 @@
+#include "WidgetCatalog/SQLUIWidgetCatalog.h"
+
+namespace
+{
+void AddSQLUIWidgetCatalogValidationError(FSQLUIWidgetCatalogValidationResult& Result, const FString& ErrorMessage)
+{
+	Result.bIsValid = false;
+	Result.Errors.Add(ErrorMessage);
+}
+
+void AddSQLUIWidgetCatalogValidationWarning(FSQLUIWidgetCatalogValidationResult& Result, const FString& WarningMessage)
+{
+	Result.Warnings.Add(WarningMessage);
+}
+
+void ValidateSQLUIWidgetCatalogSupportedKeys(
+	FSQLUIWidgetCatalogValidationResult& Result,
+	const FString& EntryLabel,
+	const TCHAR* SupportedKeyLabel,
+	const TArray<FString>& SupportedKeys)
+{
+	TSet<FString> SeenKeys;
+	for (const FString& SupportedKey : SupportedKeys)
+	{
+		if (SupportedKey.IsEmpty())
+		{
+			AddSQLUIWidgetCatalogValidationError(
+				Result,
+				FString::Printf(TEXT("SQLUI widget catalog entry '%s' includes an empty supported %s key."), *EntryLabel, SupportedKeyLabel));
+			continue;
+		}
+
+		if (SeenKeys.Contains(SupportedKey))
+		{
+			AddSQLUIWidgetCatalogValidationWarning(
+				Result,
+				FString::Printf(TEXT("SQLUI widget catalog entry '%s' lists supported %s key '%s' more than once."), *EntryLabel, SupportedKeyLabel, *SupportedKey));
+		}
+		else
+		{
+			SeenKeys.Add(SupportedKey);
+		}
+	}
+}
+
+void ValidateSQLUIWidgetCatalogEntry(
+	FSQLUIWidgetCatalogValidationResult& Result,
+	const FSQLUIWidgetCatalogEntry& Entry,
+	const FString& EntryLabel)
+{
+	if (Entry.WidgetTypeKey.Value.IsEmpty())
+	{
+		AddSQLUIWidgetCatalogValidationError(
+			Result,
+			FString::Printf(TEXT("SQLUI widget catalog entry '%s' must include a widget type key."), *EntryLabel));
+	}
+
+	ValidateSQLUIWidgetCatalogSupportedKeys(Result, EntryLabel, TEXT("property"), Entry.SupportedPropertyKeys);
+	ValidateSQLUIWidgetCatalogSupportedKeys(Result, EntryLabel, TEXT("binding"), Entry.SupportedBindingKeys);
+	ValidateSQLUIWidgetCatalogSupportedKeys(Result, EntryLabel, TEXT("action"), Entry.SupportedActionKeys);
+}
+
+void ValidateSQLUIWidgetCatalogKey(
+	FSQLUIWidgetCatalogValidationResult& Result,
+	const FString& WidgetId,
+	const FString& WidgetTypeKey,
+	const FString& KeyType,
+	const FString& Key,
+	const TArray<FString>& SupportedKeys)
+{
+	if (Key.IsEmpty())
+	{
+		return;
+	}
+
+	if (!SupportedKeys.Contains(Key))
+	{
+		AddSQLUIWidgetCatalogValidationError(
+			Result,
+			FString::Printf(
+				TEXT("SQLUI layout node '%s' of widget type '%s' uses unsupported %s key '%s'."),
+				*WidgetId,
+				*WidgetTypeKey,
+				*KeyType,
+				*Key));
+	}
+}
+}
+
+void USQLUIWidgetCatalog::SetEntries(const TArray<FSQLUIWidgetCatalogEntry>& InEntries)
+{
+	Entries = InEntries;
+}
+
+void USQLUIWidgetCatalog::ClearEntries()
+{
+	Entries.Empty();
+}
+
+bool USQLUIWidgetCatalog::RegisterEntry(const FSQLUIWidgetCatalogEntry& Entry, FSQLUIWidgetCatalogValidationResult* OutValidation)
+{
+	FSQLUIWidgetCatalogValidationResult Validation;
+	const FString EntryLabel = Entry.WidgetTypeKey.Value.IsEmpty()
+		? TEXT("new entry")
+		: Entry.WidgetTypeKey.Value;
+
+	ValidateSQLUIWidgetCatalogEntry(Validation, Entry, EntryLabel);
+
+	if (!Entry.WidgetTypeKey.Value.IsEmpty() && FindEntry(Entry.WidgetTypeKey))
+	{
+		AddSQLUIWidgetCatalogValidationError(
+			Validation,
+			FString::Printf(TEXT("SQLUI widget catalog already contains widget type key '%s'."), *Entry.WidgetTypeKey.Value));
+	}
+
+	if (OutValidation)
+	{
+		*OutValidation = Validation;
+	}
+
+	if (!Validation.bIsValid)
+	{
+		return false;
+	}
+
+	Entries.Add(Entry);
+	return true;
+}
+
+const FSQLUIWidgetCatalogEntry* USQLUIWidgetCatalog::FindEntry(const FString& WidgetTypeKey) const
+{
+	if (WidgetTypeKey.IsEmpty())
+	{
+		return nullptr;
+	}
+
+	for (const FSQLUIWidgetCatalogEntry& Entry : Entries)
+	{
+		if (Entry.WidgetTypeKey.Value == WidgetTypeKey)
+		{
+			return &Entry;
+		}
+	}
+
+	return nullptr;
+}
+
+const FSQLUIWidgetCatalogEntry* USQLUIWidgetCatalog::FindEntry(const FSQLUIWidgetTypeKey& WidgetTypeKey) const
+{
+	return FindEntry(WidgetTypeKey.Value);
+}
+
+FSQLUIWidgetCatalogValidationResult USQLUIWidgetCatalog::ValidateCatalog() const
+{
+	FSQLUIWidgetCatalogValidationResult Result;
+
+	TSet<FString> SeenWidgetTypeKeys;
+	for (int32 EntryIndex = 0; EntryIndex < Entries.Num(); ++EntryIndex)
+	{
+		const FSQLUIWidgetCatalogEntry& Entry = Entries[EntryIndex];
+		const FString EntryLabel = Entry.WidgetTypeKey.Value.IsEmpty()
+			? FString::Printf(TEXT("index %d"), EntryIndex)
+			: Entry.WidgetTypeKey.Value;
+
+		ValidateSQLUIWidgetCatalogEntry(Result, Entry, EntryLabel);
+
+		if (Entry.WidgetTypeKey.Value.IsEmpty())
+		{
+			continue;
+		}
+
+		if (SeenWidgetTypeKeys.Contains(Entry.WidgetTypeKey.Value))
+		{
+			AddSQLUIWidgetCatalogValidationError(
+				Result,
+				FString::Printf(TEXT("SQLUI widget catalog contains duplicate widget type key '%s'."), *Entry.WidgetTypeKey.Value));
+		}
+		else
+		{
+			SeenWidgetTypeKeys.Add(Entry.WidgetTypeKey.Value);
+		}
+	}
+
+	return Result;
+}
+
+FSQLUIWidgetCatalogValidationResult USQLUIWidgetCatalog::ValidateLayoutDocument(const FSQLUILayoutDocument& Document) const
+{
+	FSQLUIWidgetCatalogValidationResult Result = ValidateCatalog();
+
+	for (const FSQLUILayoutNode& Node : Document.Nodes)
+	{
+		if (Node.WidgetTypeKey.IsEmpty())
+		{
+			continue;
+		}
+
+		const FSQLUIWidgetCatalogEntry* Entry = FindEntry(Node.WidgetTypeKey);
+		if (!Entry)
+		{
+			AddSQLUIWidgetCatalogValidationError(
+				Result,
+				FString::Printf(TEXT("SQLUI layout node '%s' references unknown widget type key '%s'."), *Node.WidgetId, *Node.WidgetTypeKey));
+			continue;
+		}
+
+		for (const TPair<FString, FString>& PropertyPair : Node.Properties)
+		{
+			ValidateSQLUIWidgetCatalogKey(
+				Result,
+				Node.WidgetId,
+				Node.WidgetTypeKey,
+				TEXT("property"),
+				PropertyPair.Key,
+				Entry->SupportedPropertyKeys);
+		}
+
+		for (const FSQLUILayoutBinding& Binding : Node.Bindings)
+		{
+			ValidateSQLUIWidgetCatalogKey(
+				Result,
+				Node.WidgetId,
+				Node.WidgetTypeKey,
+				TEXT("binding target property"),
+				Binding.TargetProperty,
+				Entry->SupportedPropertyKeys);
+
+			ValidateSQLUIWidgetCatalogKey(
+				Result,
+				Node.WidgetId,
+				Node.WidgetTypeKey,
+				TEXT("binding"),
+				Binding.SourceKey,
+				Entry->SupportedBindingKeys);
+		}
+
+		for (const FSQLUILayoutAction& Action : Node.Actions)
+		{
+			ValidateSQLUIWidgetCatalogKey(
+				Result,
+				Node.WidgetId,
+				Node.WidgetTypeKey,
+				TEXT("action"),
+				Action.ActionTypeKey,
+				Entry->SupportedActionKeys);
+		}
+	}
+
+	return Result;
+}

--- a/Plugins/SQLUI/Source/SQLUICore/Public/Layout/SQLUILayoutFactory.h
+++ b/Plugins/SQLUI/Source/SQLUICore/Public/Layout/SQLUILayoutFactory.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Layout/SQLUILayoutTypes.h"
+#include "UObject/Object.h"
+#include "WidgetCatalog/SQLUIWidgetCatalog.h"
+
+#include "SQLUILayoutFactory.generated.h"
+
+USTRUCT(BlueprintType)
+struct SQLUICORE_API FSQLUILayoutFactoryRequest
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Factory")
+	FSQLUILayoutDocument Document;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Factory")
+	TObjectPtr<USQLUIWidgetCatalog> WidgetCatalog = nullptr;
+};
+
+USTRUCT(BlueprintType)
+struct SQLUICORE_API FSQLUILayoutFactoryResult
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Factory")
+	bool bSucceeded = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Factory")
+	FString ErrorMessage;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Factory")
+	FSQLUILayoutValidationResult LayoutValidation;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Factory")
+	FSQLUIWidgetCatalogValidationResult CatalogValidation;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Factory")
+	FSQLUILayoutDocument PreparedDocument;
+};
+
+UCLASS(BlueprintType)
+class SQLUICORE_API USQLUILayoutFactory : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	FSQLUILayoutFactoryResult PrepareLayout(const FSQLUILayoutFactoryRequest& Request) const;
+};

--- a/Plugins/SQLUI/Source/SQLUICore/Public/WidgetCatalog/SQLUIWidgetCatalog.h
+++ b/Plugins/SQLUI/Source/SQLUICore/Public/WidgetCatalog/SQLUIWidgetCatalog.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Layout/SQLUILayoutTypes.h"
+#include "UObject/Object.h"
+
+#include "SQLUIWidgetCatalog.generated.h"
+
+USTRUCT(BlueprintType)
+struct SQLUICORE_API FSQLUIWidgetTypeKey
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Catalog")
+	FString Value;
+};
+
+USTRUCT(BlueprintType)
+struct SQLUICORE_API FSQLUIWidgetCatalogEntry
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Catalog")
+	FSQLUIWidgetTypeKey WidgetTypeKey;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Catalog")
+	FString DisplayName;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Catalog")
+	FString Description;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Catalog")
+	FString WidgetClassPath;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Catalog")
+	TArray<FString> SupportedPropertyKeys;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Catalog")
+	TArray<FString> SupportedBindingKeys;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Catalog")
+	TArray<FString> SupportedActionKeys;
+};
+
+USTRUCT(BlueprintType)
+struct SQLUICORE_API FSQLUIWidgetCatalogValidationResult
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Catalog")
+	bool bIsValid = true;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Catalog")
+	TArray<FString> Errors;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Catalog")
+	TArray<FString> Warnings;
+};
+
+UCLASS(BlueprintType)
+class SQLUICORE_API USQLUIWidgetCatalog : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Catalog")
+	TArray<FSQLUIWidgetCatalogEntry> Entries;
+
+	void SetEntries(const TArray<FSQLUIWidgetCatalogEntry>& InEntries);
+	void ClearEntries();
+	bool RegisterEntry(const FSQLUIWidgetCatalogEntry& Entry, FSQLUIWidgetCatalogValidationResult* OutValidation = nullptr);
+
+	const FSQLUIWidgetCatalogEntry* FindEntry(const FString& WidgetTypeKey) const;
+	const FSQLUIWidgetCatalogEntry* FindEntry(const FSQLUIWidgetTypeKey& WidgetTypeKey) const;
+
+	FSQLUIWidgetCatalogValidationResult ValidateCatalog() const;
+	FSQLUIWidgetCatalogValidationResult ValidateLayoutDocument(const FSQLUILayoutDocument& Document) const;
+};


### PR DESCRIPTION
Summary
- Added SQLUI widget catalog types and catalog UObject skeleton
- Added catalog validation for layout documents
- Added layout factory request/result types
- Added layout factory skeleton that prepares and validates layouts
- Kept the work limited to SQLUICore

Validation
- Ran git diff --check
- Built JerryRiggedEditor Win64 Development successfully

Notes
- No real UMG widget construction yet
- No SQLite/database behavior
- No host-game logic
- No SQLUIWidgets or SQLUISamples changes