### PR TITLE
Add SQLUI runtime context and binding resolver skeleton

### DIFF
--- a/Plugins/SQLUI/Source/SQLUICore/Private/Bindings/SQLUIBindingResolver.cpp
+++ b/Plugins/SQLUI/Source/SQLUICore/Private/Bindings/SQLUIBindingResolver.cpp
@@ -1,0 +1,115 @@
+#include "Bindings/SQLUIBindingResolver.h"
+
+#include "Runtime/SQLUIRuntimeContext.h"
+#include "Variables/SQLUIVariableStore.h"
+
+namespace
+{
+bool IsSQLUIVariableBindingSource(const FString& SourceKey)
+{
+	return SourceKey.Equals(TEXT("Variable"), ESearchCase::IgnoreCase) ||
+		SourceKey.Equals(TEXT("VariableStore"), ESearchCase::IgnoreCase);
+}
+
+FString GetSQLUIBindingLabel(const FSQLUILayoutBinding& Binding)
+{
+	if (!Binding.BindingId.IsEmpty())
+	{
+		return Binding.BindingId;
+	}
+
+	return Binding.TargetProperty;
+}
+
+FSQLUIBindingResolveResult MakeSQLUIBindingUnavailableResult(
+	const FSQLUILayoutBinding& Binding,
+	const FString& Reason,
+	const bool bNotImplemented)
+{
+	FSQLUIBindingResolveResult Result;
+	Result.bSucceeded = false;
+	Result.bBindingUnavailable = true;
+	Result.bNotImplemented = bNotImplemented;
+
+	const FString BindingLabel = GetSQLUIBindingLabel(Binding);
+	Result.ErrorMessage = BindingLabel.IsEmpty()
+		? Reason
+		: FString::Printf(TEXT("SQLUI binding '%s' is unavailable: %s"), *BindingLabel, *Reason);
+
+	return Result;
+}
+}
+
+FSQLUIBindingResolveResult USQLUIBindingResolver::ResolveBinding(
+	const FSQLUIBindingResolveRequest& Request,
+	const USQLUIRuntimeContext* RuntimeContext) const
+{
+	const FSQLUILayoutBinding& Binding = Request.Binding;
+
+	if (!RuntimeContext)
+	{
+		return MakeSQLUIBindingUnavailableResult(
+			Binding,
+			TEXT("runtime context was not provided."),
+			false);
+	}
+
+	if (Binding.SourceKey.IsEmpty())
+	{
+		return MakeSQLUIBindingUnavailableResult(
+			Binding,
+			TEXT("no binding source key was provided."),
+			false);
+	}
+
+	if (!IsSQLUIVariableBindingSource(Binding.SourceKey))
+	{
+		return MakeSQLUIBindingUnavailableResult(
+			Binding,
+			FString::Printf(TEXT("binding source key '%s' is not implemented yet."), *Binding.SourceKey),
+			true);
+	}
+
+	if (Binding.SourcePath.IsEmpty())
+	{
+		return MakeSQLUIBindingUnavailableResult(
+			Binding,
+			TEXT("variable bindings require SourcePath to name a variable."),
+			false);
+	}
+
+	const USQLUIVariableStore* VariableStore = RuntimeContext->GetVariableStore();
+	if (!VariableStore)
+	{
+		return MakeSQLUIBindingUnavailableResult(
+			Binding,
+			TEXT("runtime context has no variable store."),
+			false);
+	}
+
+	FSQLUIVariableKey VariableKey;
+	VariableKey.Name = Binding.SourcePath;
+
+	FSQLUIVariableValue ResolvedValue;
+	if (!VariableStore->GetVariable(VariableKey, ResolvedValue))
+	{
+		return MakeSQLUIBindingUnavailableResult(
+			Binding,
+			FString::Printf(TEXT("variable '%s' is not available."), *VariableKey.Name),
+			false);
+	}
+
+	FSQLUIBindingResolveResult Result;
+	Result.bSucceeded = true;
+	Result.ResolvedValue = ResolvedValue;
+	return Result;
+}
+
+FSQLUIBindingResolveResult USQLUIBindingResolver::ResolveLayoutBinding(
+	const FSQLUILayoutBinding& Binding,
+	const USQLUIRuntimeContext* RuntimeContext) const
+{
+	FSQLUIBindingResolveRequest Request;
+	Request.Binding = Binding;
+	return ResolveBinding(Request, RuntimeContext);
+}

--- a/Plugins/SQLUI/Source/SQLUICore/Private/Runtime/SQLUIRuntimeContext.cpp
+++ b/Plugins/SQLUI/Source/SQLUICore/Private/Runtime/SQLUIRuntimeContext.cpp
@@ -1,0 +1,59 @@
+#include "Runtime/SQLUIRuntimeContext.h"
+
+#include "Actions/SQLUIActionRegistry.h"
+#include "Layout/SQLUILayoutFactory.h"
+#include "Variables/SQLUIVariableStore.h"
+#include "WidgetCatalog/SQLUIWidgetCatalog.h"
+
+namespace
+{
+template <typename ServiceType>
+ServiceType* ResolveSQLUIRuntimeService(UObject* Outer, ServiceType* ProvidedService)
+{
+	if (IsValid(ProvidedService))
+	{
+		return ProvidedService;
+	}
+
+	return NewObject<ServiceType>(Outer);
+}
+}
+
+void USQLUIRuntimeContext::Initialize(const FSQLUIRuntimeContextSettings& InSettings)
+{
+	VariableStore = ResolveSQLUIRuntimeService(this, InSettings.VariableStore.Get());
+	ActionRegistry = ResolveSQLUIRuntimeService(this, InSettings.ActionRegistry.Get());
+	WidgetCatalog = ResolveSQLUIRuntimeService(this, InSettings.WidgetCatalog.Get());
+	LayoutFactory = ResolveSQLUIRuntimeService(this, InSettings.LayoutFactory.Get());
+
+	bInitialized =
+		IsValid(VariableStore) &&
+		IsValid(ActionRegistry) &&
+		IsValid(WidgetCatalog) &&
+		IsValid(LayoutFactory);
+}
+
+bool USQLUIRuntimeContext::IsInitialized() const
+{
+	return bInitialized;
+}
+
+USQLUIVariableStore* USQLUIRuntimeContext::GetVariableStore() const
+{
+	return VariableStore.Get();
+}
+
+USQLUIActionRegistry* USQLUIRuntimeContext::GetActionRegistry() const
+{
+	return ActionRegistry.Get();
+}
+
+USQLUIWidgetCatalog* USQLUIRuntimeContext::GetWidgetCatalog() const
+{
+	return WidgetCatalog.Get();
+}
+
+USQLUILayoutFactory* USQLUIRuntimeContext::GetLayoutFactory() const
+{
+	return LayoutFactory.Get();
+}

--- a/Plugins/SQLUI/Source/SQLUICore/Public/Bindings/SQLUIBindingResolver.h
+++ b/Plugins/SQLUI/Source/SQLUICore/Public/Bindings/SQLUIBindingResolver.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Bindings/SQLUIBindingTypes.h"
+#include "CoreMinimal.h"
+#include "UObject/Object.h"
+
+#include "SQLUIBindingResolver.generated.h"
+
+class USQLUIRuntimeContext;
+
+UCLASS(BlueprintType)
+class SQLUICORE_API USQLUIBindingResolver : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	FSQLUIBindingResolveResult ResolveBinding(
+		const FSQLUIBindingResolveRequest& Request,
+		const USQLUIRuntimeContext* RuntimeContext) const;
+
+	FSQLUIBindingResolveResult ResolveLayoutBinding(
+		const FSQLUILayoutBinding& Binding,
+		const USQLUIRuntimeContext* RuntimeContext) const;
+};

--- a/Plugins/SQLUI/Source/SQLUICore/Public/Bindings/SQLUIBindingTypes.h
+++ b/Plugins/SQLUI/Source/SQLUICore/Public/Bindings/SQLUIBindingTypes.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Layout/SQLUILayoutTypes.h"
+#include "Variables/SQLUIVariableTypes.h"
+
+#include "SQLUIBindingTypes.generated.h"
+
+USTRUCT(BlueprintType)
+struct SQLUICORE_API FSQLUIBindingResolveRequest
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Bindings")
+	FSQLUILayoutBinding Binding;
+};
+
+USTRUCT(BlueprintType)
+struct SQLUICORE_API FSQLUIBindingResolveResult
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Bindings")
+	bool bSucceeded = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Bindings")
+	bool bBindingUnavailable = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Bindings")
+	bool bNotImplemented = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Bindings")
+	FString ErrorMessage;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Bindings")
+	FSQLUIVariableValue ResolvedValue;
+};

--- a/Plugins/SQLUI/Source/SQLUICore/Public/Runtime/SQLUIRuntimeContext.h
+++ b/Plugins/SQLUI/Source/SQLUICore/Public/Runtime/SQLUIRuntimeContext.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/Object.h"
+
+#include "SQLUIRuntimeContext.generated.h"
+
+class USQLUIActionRegistry;
+class USQLUILayoutFactory;
+class USQLUIVariableStore;
+class USQLUIWidgetCatalog;
+
+USTRUCT(BlueprintType)
+struct SQLUICORE_API FSQLUIRuntimeContextSettings
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Runtime")
+	TObjectPtr<USQLUIVariableStore> VariableStore = nullptr;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Runtime")
+	TObjectPtr<USQLUIActionRegistry> ActionRegistry = nullptr;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Runtime")
+	TObjectPtr<USQLUIWidgetCatalog> WidgetCatalog = nullptr;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Runtime")
+	TObjectPtr<USQLUILayoutFactory> LayoutFactory = nullptr;
+};
+
+UCLASS(BlueprintType)
+class SQLUICORE_API USQLUIRuntimeContext : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	void Initialize(const FSQLUIRuntimeContextSettings& InSettings);
+
+	bool IsInitialized() const;
+
+	USQLUIVariableStore* GetVariableStore() const;
+	USQLUIActionRegistry* GetActionRegistry() const;
+	USQLUIWidgetCatalog* GetWidgetCatalog() const;
+	USQLUILayoutFactory* GetLayoutFactory() const;
+
+private:
+	UPROPERTY(Transient)
+	TObjectPtr<USQLUIVariableStore> VariableStore = nullptr;
+
+	UPROPERTY(Transient)
+	TObjectPtr<USQLUIActionRegistry> ActionRegistry = nullptr;
+
+	UPROPERTY(Transient)
+	TObjectPtr<USQLUIWidgetCatalog> WidgetCatalog = nullptr;
+
+	UPROPERTY(Transient)
+	TObjectPtr<USQLUILayoutFactory> LayoutFactory = nullptr;
+
+	bool bInitialized = false;
+};


### PR DESCRIPTION
Summary
- Added SQLUI runtime context settings and context object
- Added runtime service references for variable store, action registry, widget catalog, and layout factory
- Added binding resolve request/result types
- Added binding resolver skeleton for simple variable-store bindings
- Kept the work limited to SQLUICore

Validation
- Ran git diff --check
- Built JerryRiggedEditor Win64 Development successfully

Notes
- No SQLite/database behavior
- No real UMG widget construction
- No game-specific actions
- No host-game logic
- No SQLUIWidgets or SQLUISamples changes