### PR TITLE
Add SQLUI widget catalog registrar skeleton

### DIFF
--- a/Plugins/SQLUI/Source/SQLUIWidgets/Private/WidgetCatalog/SQLUIWidgetCatalogRegistrar.cpp
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Private/WidgetCatalog/SQLUIWidgetCatalogRegistrar.cpp
@@ -1,0 +1,124 @@
+#include "WidgetCatalog/SQLUIWidgetCatalogRegistrar.h"
+
+#include "Widgets/SQLUIFilterBox.h"
+#include "Widgets/SQLUIListItemWidget.h"
+#include "Widgets/SQLUIListWidget.h"
+
+namespace
+{
+FSQLUIWidgetTypeKey MakeSQLUIWidgetTypeKey(const TCHAR* Value)
+{
+	FSQLUIWidgetTypeKey Key;
+	Key.Value = Value;
+	return Key;
+}
+
+TArray<FString> MakeSQLUIVariableBindingKeys()
+{
+	return {
+		TEXT("Variable"),
+		TEXT("VariableStore")
+	};
+}
+}
+
+FSQLUIWidgetTypeKey FSQLUIWidgetTypeKeys::FilterBox()
+{
+	return MakeSQLUIWidgetTypeKey(TEXT("SQLUI.FilterBox"));
+}
+
+FSQLUIWidgetTypeKey FSQLUIWidgetTypeKeys::ListWidget()
+{
+	return MakeSQLUIWidgetTypeKey(TEXT("SQLUI.ListWidget"));
+}
+
+FSQLUIWidgetTypeKey FSQLUIWidgetTypeKeys::ListItemWidget()
+{
+	return MakeSQLUIWidgetTypeKey(TEXT("SQLUI.ListItemWidget"));
+}
+
+bool USQLUIWidgetCatalogRegistrar::RegisterDefaultSQLUIWidgets(USQLUIWidgetCatalog* WidgetCatalog)
+{
+	if (!WidgetCatalog)
+	{
+		return false;
+	}
+
+	bool bRegisteredAll = true;
+	bRegisteredAll &= RegisterFilterBox(WidgetCatalog);
+	bRegisteredAll &= RegisterListWidget(WidgetCatalog);
+	bRegisteredAll &= RegisterListItemWidget(WidgetCatalog);
+	return bRegisteredAll;
+}
+
+bool USQLUIWidgetCatalogRegistrar::RegisterFilterBox(USQLUIWidgetCatalog* WidgetCatalog)
+{
+	if (!WidgetCatalog)
+	{
+		return false;
+	}
+
+	FSQLUIWidgetCatalogEntry Entry;
+	Entry.WidgetTypeKey = FSQLUIWidgetTypeKeys::FilterBox();
+	Entry.DisplayName = TEXT("Filter Box");
+	Entry.Description = TEXT("SQLUI filter input widget metadata.");
+	Entry.WidgetClassPath = USQLUIFilterBox::StaticClass()->GetPathName();
+	Entry.SupportedPropertyKeys = {
+		TEXT("FilterText"),
+		TEXT("PlaceholderText"),
+		TEXT("IsEnabled")
+	};
+	Entry.SupportedBindingKeys = MakeSQLUIVariableBindingKeys();
+	Entry.SupportedActionKeys = {};
+
+	return WidgetCatalog->RegisterEntry(Entry);
+}
+
+bool USQLUIWidgetCatalogRegistrar::RegisterListWidget(USQLUIWidgetCatalog* WidgetCatalog)
+{
+	if (!WidgetCatalog)
+	{
+		return false;
+	}
+
+	FSQLUIWidgetCatalogEntry Entry;
+	Entry.WidgetTypeKey = FSQLUIWidgetTypeKeys::ListWidget();
+	Entry.DisplayName = TEXT("List Widget");
+	Entry.Description = TEXT("SQLUI list widget metadata.");
+	Entry.WidgetClassPath = USQLUIListWidget::StaticClass()->GetPathName();
+	Entry.SupportedPropertyKeys = {
+		TEXT("Items"),
+		TEXT("EmptyText"),
+		TEXT("SelectionMode"),
+		TEXT("IsEnabled")
+	};
+	Entry.SupportedBindingKeys = MakeSQLUIVariableBindingKeys();
+	Entry.SupportedActionKeys = {};
+
+	return WidgetCatalog->RegisterEntry(Entry);
+}
+
+bool USQLUIWidgetCatalogRegistrar::RegisterListItemWidget(USQLUIWidgetCatalog* WidgetCatalog)
+{
+	if (!WidgetCatalog)
+	{
+		return false;
+	}
+
+	FSQLUIWidgetCatalogEntry Entry;
+	Entry.WidgetTypeKey = FSQLUIWidgetTypeKeys::ListItemWidget();
+	Entry.DisplayName = TEXT("List Item Widget");
+	Entry.Description = TEXT("SQLUI list item widget metadata.");
+	Entry.WidgetClassPath = USQLUIListItemWidget::StaticClass()->GetPathName();
+	Entry.SupportedPropertyKeys = {
+		TEXT("ItemId"),
+		TEXT("DisplayText"),
+		TEXT("Properties"),
+		TEXT("Metadata"),
+		TEXT("IsSelected")
+	};
+	Entry.SupportedBindingKeys = MakeSQLUIVariableBindingKeys();
+	Entry.SupportedActionKeys = {};
+
+	return WidgetCatalog->RegisterEntry(Entry);
+}

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Public/WidgetCatalog/SQLUIWidgetCatalogRegistrar.h
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Public/WidgetCatalog/SQLUIWidgetCatalogRegistrar.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/Object.h"
+#include "WidgetCatalog/SQLUIWidgetCatalog.h"
+
+#include "SQLUIWidgetCatalogRegistrar.generated.h"
+
+struct SQLUIWIDGETS_API FSQLUIWidgetTypeKeys
+{
+	static FSQLUIWidgetTypeKey FilterBox();
+	static FSQLUIWidgetTypeKey ListWidget();
+	static FSQLUIWidgetTypeKey ListItemWidget();
+};
+
+UCLASS()
+class SQLUIWIDGETS_API USQLUIWidgetCatalogRegistrar : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	static bool RegisterDefaultSQLUIWidgets(USQLUIWidgetCatalog* WidgetCatalog);
+	static bool RegisterFilterBox(USQLUIWidgetCatalog* WidgetCatalog);
+	static bool RegisterListWidget(USQLUIWidgetCatalog* WidgetCatalog);
+	static bool RegisterListItemWidget(USQLUIWidgetCatalog* WidgetCatalog);
+};


### PR DESCRIPTION
Summary
- Added SQLUI widget catalog registrar skeleton
- Added stable default SQLUI widget type keys
- Added registration helpers for FilterBox, ListWidget, and ListItemWidget
- Registered metadata for supported properties and bindings
- Kept the work focused inside SQLUIWidgets

Validation
- Ran git diff --check
- Built JerryRiggedEditor Win64 Development successfully

Notes
- No real widget construction yet
- No SQLite/database behavior
- No host-game logic
- No SQLUISamples changes
- No runtime layout rendering yet