### PR TITLE
Add SQLUI layout widget factory bridge skeleton

### DIFF
--- a/Plugins/SQLUI/Source/SQLUIWidgets/Private/Layout/SQLUILayoutWidgetFactory.cpp
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Private/Layout/SQLUILayoutWidgetFactory.cpp
@@ -1,0 +1,139 @@
+#include "Layout/SQLUILayoutWidgetFactory.h"
+
+#include "Layout/SQLUILayoutJson.h"
+
+namespace
+{
+void AddSQLUIWidgetBuildCatalogError(FSQLUIWidgetBuildResult& Result, const FString& ErrorMessage)
+{
+	Result.CatalogValidation.bIsValid = false;
+	Result.CatalogValidation.Errors.Add(ErrorMessage);
+	Result.ErrorMessage = ErrorMessage;
+}
+
+UClass* ResolveSQLUIWidgetClass(const FString& WidgetClassPath)
+{
+	UClass* WidgetClass = FindObject<UClass>(nullptr, *WidgetClassPath);
+	if (!WidgetClass)
+	{
+		WidgetClass = LoadObject<UClass>(nullptr, *WidgetClassPath);
+	}
+
+	return WidgetClass;
+}
+
+FSQLUIWidgetBuildResult PrepareSQLUILayoutWidgetBuild(const FSQLUIWidgetBuildRequest& Request)
+{
+	FSQLUIWidgetBuildResult Result;
+	Result.RootWidgetId = Request.Document.RootWidgetId;
+
+	if (!Request.RuntimeContext)
+	{
+		Result.ErrorMessage = TEXT("SQLUI layout widget factory requires a runtime context before preparing a widget build.");
+		return Result;
+	}
+
+	if (!Request.RuntimeContext->IsInitialized())
+	{
+		Result.ErrorMessage = TEXT("SQLUI layout widget factory requires an initialized runtime context before preparing a widget build.");
+		return Result;
+	}
+
+	USQLUIWidgetCatalog* WidgetCatalog = Request.WidgetCatalogOverride
+		? Request.WidgetCatalogOverride.Get()
+		: Request.RuntimeContext->GetWidgetCatalog();
+
+	if (!WidgetCatalog)
+	{
+		AddSQLUIWidgetBuildCatalogError(
+			Result,
+			TEXT("SQLUI layout widget factory requires a widget catalog before preparing a widget build."));
+		return Result;
+	}
+
+	Result.LayoutValidation = FSQLUILayoutJson::ValidateDocument(Request.Document);
+	if (!Result.LayoutValidation.bIsValid)
+	{
+		Result.ErrorMessage = TEXT("SQLUI layout widget factory could not prepare an invalid layout document.");
+		return Result;
+	}
+
+	Result.CatalogValidation = WidgetCatalog->ValidateLayoutDocument(Request.Document);
+	if (!Result.CatalogValidation.bIsValid)
+	{
+		Result.ErrorMessage = TEXT("SQLUI layout widget factory could not prepare a layout that failed widget catalog validation.");
+		return Result;
+	}
+
+	TArray<FSQLUIPreparedWidgetBuildNode> PreparedNodes;
+	PreparedNodes.Reserve(Request.Document.Nodes.Num());
+
+	for (const FSQLUILayoutNode& LayoutNode : Request.Document.Nodes)
+	{
+		const FSQLUIWidgetCatalogEntry* CatalogEntry = WidgetCatalog->FindEntry(LayoutNode.WidgetTypeKey);
+		if (!CatalogEntry)
+		{
+			AddSQLUIWidgetBuildCatalogError(
+				Result,
+				FString::Printf(
+					TEXT("SQLUI layout node '%s' references unknown widget type key '%s'."),
+					*LayoutNode.WidgetId,
+					*LayoutNode.WidgetTypeKey));
+			return Result;
+		}
+
+		if (CatalogEntry->WidgetClassPath.IsEmpty())
+		{
+			AddSQLUIWidgetBuildCatalogError(
+				Result,
+				FString::Printf(
+					TEXT("SQLUI widget type '%s' does not include a widget class path."),
+					*CatalogEntry->WidgetTypeKey.Value));
+			return Result;
+		}
+
+		UClass* WidgetClass = ResolveSQLUIWidgetClass(CatalogEntry->WidgetClassPath);
+		if (!WidgetClass)
+		{
+			AddSQLUIWidgetBuildCatalogError(
+				Result,
+				FString::Printf(
+					TEXT("SQLUI widget type '%s' could not resolve widget class path '%s'."),
+					*CatalogEntry->WidgetTypeKey.Value,
+					*CatalogEntry->WidgetClassPath));
+			return Result;
+		}
+
+		if (!WidgetClass->IsChildOf(USQLUIBaseWidget::StaticClass()))
+		{
+			AddSQLUIWidgetBuildCatalogError(
+				Result,
+				FString::Printf(
+					TEXT("SQLUI widget type '%s' resolved class '%s' is not a USQLUIBaseWidget."),
+					*CatalogEntry->WidgetTypeKey.Value,
+					*WidgetClass->GetPathName()));
+			return Result;
+		}
+
+		FSQLUIPreparedWidgetBuildNode PreparedNode;
+		PreparedNode.LayoutNode = LayoutNode;
+		PreparedNode.CatalogEntry = *CatalogEntry;
+		PreparedNode.WidgetClass = WidgetClass;
+		PreparedNodes.Add(PreparedNode);
+	}
+
+	Result.PreparedNodes = MoveTemp(PreparedNodes);
+	Result.bSucceeded = true;
+	return Result;
+}
+}
+
+FSQLUIWidgetBuildResult USQLUILayoutWidgetBuilder::PrepareBuild(const FSQLUIWidgetBuildRequest& Request) const
+{
+	return PrepareSQLUILayoutWidgetBuild(Request);
+}
+
+FSQLUIWidgetBuildResult USQLUILayoutWidgetFactory::PrepareBuild(const FSQLUIWidgetBuildRequest& Request) const
+{
+	return PrepareSQLUILayoutWidgetBuild(Request);
+}

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Public/Layout/SQLUILayoutWidgetFactory.h
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Public/Layout/SQLUILayoutWidgetFactory.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Layout/SQLUILayoutTypes.h"
+#include "Runtime/SQLUIRuntimeContext.h"
+#include "UObject/Object.h"
+#include "WidgetCatalog/SQLUIWidgetCatalog.h"
+#include "Widgets/SQLUIBaseWidget.h"
+
+#include "SQLUILayoutWidgetFactory.generated.h"
+
+USTRUCT(BlueprintType)
+struct SQLUIWIDGETS_API FSQLUIWidgetBuildRequest
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Widget Factory")
+	FSQLUILayoutDocument Document;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Widget Factory")
+	TObjectPtr<USQLUIRuntimeContext> RuntimeContext = nullptr;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Widget Factory")
+	TObjectPtr<USQLUIWidgetCatalog> WidgetCatalogOverride = nullptr;
+};
+
+USTRUCT(BlueprintType)
+struct SQLUIWIDGETS_API FSQLUIPreparedWidgetBuildNode
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Widget Factory")
+	FSQLUILayoutNode LayoutNode;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Widget Factory")
+	FSQLUIWidgetCatalogEntry CatalogEntry;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Widget Factory")
+	TSubclassOf<USQLUIBaseWidget> WidgetClass = nullptr;
+};
+
+USTRUCT(BlueprintType)
+struct SQLUIWIDGETS_API FSQLUIWidgetBuildResult
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Widget Factory")
+	bool bSucceeded = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Widget Factory")
+	FString ErrorMessage;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Widget Factory")
+	FSQLUILayoutValidationResult LayoutValidation;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Widget Factory")
+	FSQLUIWidgetCatalogValidationResult CatalogValidation;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Widget Factory")
+	FString RootWidgetId;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Widget Factory")
+	TArray<FSQLUIPreparedWidgetBuildNode> PreparedNodes;
+};
+
+UCLASS(BlueprintType)
+class SQLUIWIDGETS_API USQLUILayoutWidgetBuilder : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	UFUNCTION(BlueprintCallable, Category = "SQLUI|Layout Widget Factory")
+	FSQLUIWidgetBuildResult PrepareBuild(const FSQLUIWidgetBuildRequest& Request) const;
+};
+
+UCLASS(BlueprintType)
+class SQLUIWIDGETS_API USQLUILayoutWidgetFactory : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	UFUNCTION(BlueprintCallable, Category = "SQLUI|Layout Widget Factory")
+	FSQLUIWidgetBuildResult PrepareBuild(const FSQLUIWidgetBuildRequest& Request) const;
+};


### PR DESCRIPTION
Summary
- Added SQLUI layout-to-widget factory bridge skeleton
- Added widget build request/result types
- Added prepared widget build node data
- Added prepare-only builder/factory API
- Validates layout and catalog metadata before future widget construction
- Kept the work focused inside SQLUIWidgets

Validation
- Ran git diff --check
- Built JerryRiggedEditor Win64 Development successfully

Notes
- Does not implement GitHub Issue #9, which is the optional editor builder MVP
- No real widget construction yet
- No recursive runtime renderer yet
- No SQLite/database behavior
- No host-game logic
- No SQLUISamples changes
- No editor tooling