### PR TITLE
Add SQLUI widget construction skeleton

### DIFF
--- a/Plugins/SQLUI/Source/SQLUIWidgets/Private/Construction/SQLUIWidgetConstructor.cpp
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Private/Construction/SQLUIWidgetConstructor.cpp
@@ -1,0 +1,186 @@
+#include "Construction/SQLUIWidgetConstructor.h"
+
+#include "Blueprint/UserWidget.h"
+#include "Engine/Engine.h"
+#include "Engine/World.h"
+#include "Runtime/SQLUIRuntimeContext.h"
+#include "Widgets/SQLUIBaseWidget.h"
+
+namespace
+{
+void AddSQLUIWidgetConstructionError(FSQLUIWidgetConstructionResult& Result, const FString& ErrorMessage)
+{
+	Result.bSucceeded = false;
+	Result.Errors.Add(ErrorMessage);
+
+	if (Result.ErrorMessage.IsEmpty())
+	{
+		Result.ErrorMessage = ErrorMessage;
+	}
+}
+
+UWorld* ResolveSQLUIWidgetConstructionWorld(const FSQLUIWidgetConstructionRequest& Request)
+{
+	if (IsValid(Request.OwningPlayer.Get()))
+	{
+		return Request.OwningPlayer->GetWorld();
+	}
+
+	if (!IsValid(Request.WorldContextObject.Get()) || !GEngine)
+	{
+		return nullptr;
+	}
+
+	return GEngine->GetWorldFromContextObject(Request.WorldContextObject.Get(), EGetWorldErrorMode::ReturnNull);
+}
+
+void ValidateSQLUIWidgetConstructionRequest(
+	const FSQLUIWidgetConstructionRequest& Request,
+	FSQLUIWidgetConstructionResult& Result)
+{
+	if (!IsValid(Request.RuntimeContext.Get()))
+	{
+		AddSQLUIWidgetConstructionError(
+			Result,
+			TEXT("SQLUI widget construction requires a runtime context."));
+	}
+	else if (!Request.RuntimeContext->IsInitialized())
+	{
+		AddSQLUIWidgetConstructionError(
+			Result,
+			TEXT("SQLUI widget construction requires an initialized runtime context."));
+	}
+
+	if (Request.OwningPlayer && !IsValid(Request.OwningPlayer.Get()))
+	{
+		AddSQLUIWidgetConstructionError(
+			Result,
+			TEXT("SQLUI widget construction received an invalid owning player."));
+	}
+
+	if (!IsValid(Request.OwningPlayer.Get()) && !ResolveSQLUIWidgetConstructionWorld(Request))
+	{
+		AddSQLUIWidgetConstructionError(
+			Result,
+			TEXT("SQLUI widget construction requires an owning player or a resolvable world context."));
+	}
+
+	if (Request.PreparedNodes.IsEmpty())
+	{
+		AddSQLUIWidgetConstructionError(
+			Result,
+			TEXT("SQLUI widget construction requires at least one prepared widget build node."));
+	}
+
+	TSet<FString> WidgetIds;
+	for (const FSQLUIPreparedWidgetBuildNode& PreparedNode : Request.PreparedNodes)
+	{
+		const FString& WidgetId = PreparedNode.LayoutNode.WidgetId;
+		if (WidgetId.IsEmpty())
+		{
+			AddSQLUIWidgetConstructionError(
+				Result,
+				TEXT("SQLUI widget construction found a prepared node without a widget id."));
+		}
+		else if (WidgetIds.Contains(WidgetId))
+		{
+			AddSQLUIWidgetConstructionError(
+				Result,
+				FString::Printf(TEXT("SQLUI widget construction found duplicate widget id '%s'."), *WidgetId));
+		}
+		else
+		{
+			WidgetIds.Add(WidgetId);
+		}
+
+		UClass* WidgetClass = PreparedNode.WidgetClass.Get();
+		if (!WidgetClass)
+		{
+			AddSQLUIWidgetConstructionError(
+				Result,
+				WidgetId.IsEmpty()
+					? TEXT("SQLUI widget construction found a prepared node without a widget class.")
+					: FString::Printf(TEXT("SQLUI widget construction node '%s' does not include a widget class."), *WidgetId));
+			continue;
+		}
+
+		if (!WidgetClass->IsChildOf(USQLUIBaseWidget::StaticClass()))
+		{
+			AddSQLUIWidgetConstructionError(
+				Result,
+				WidgetId.IsEmpty()
+					? FString::Printf(TEXT("SQLUI widget construction class '%s' is not a USQLUIBaseWidget."), *WidgetClass->GetPathName())
+					: FString::Printf(TEXT("SQLUI widget construction node '%s' uses class '%s', which is not a USQLUIBaseWidget."), *WidgetId, *WidgetClass->GetPathName()));
+		}
+
+		if (WidgetClass->HasAnyClassFlags(CLASS_Abstract))
+		{
+			AddSQLUIWidgetConstructionError(
+				Result,
+				WidgetId.IsEmpty()
+					? FString::Printf(TEXT("SQLUI widget construction class '%s' is abstract."), *WidgetClass->GetPathName())
+					: FString::Printf(TEXT("SQLUI widget construction node '%s' uses abstract class '%s'."), *WidgetId, *WidgetClass->GetPathName()));
+		}
+	}
+
+	if (!Request.RootWidgetId.IsEmpty() && !WidgetIds.Contains(Request.RootWidgetId))
+	{
+		AddSQLUIWidgetConstructionError(
+			Result,
+			FString::Printf(TEXT("SQLUI widget construction root widget id '%s' does not match a prepared node."), *Request.RootWidgetId));
+	}
+}
+}
+
+FSQLUIWidgetConstructionResult USQLUIWidgetConstructor::ConstructWidgets(const FSQLUIWidgetConstructionRequest& Request) const
+{
+	FSQLUIWidgetConstructionResult Result;
+	ValidateSQLUIWidgetConstructionRequest(Request, Result);
+
+	if (!Result.Errors.IsEmpty())
+	{
+		return Result;
+	}
+
+	UWorld* World = ResolveSQLUIWidgetConstructionWorld(Request);
+	for (const FSQLUIPreparedWidgetBuildNode& PreparedNode : Request.PreparedNodes)
+	{
+		UClass* WidgetClass = PreparedNode.WidgetClass.Get();
+		USQLUIBaseWidget* CreatedWidget = Request.OwningPlayer
+			? CreateWidget<USQLUIBaseWidget>(Request.OwningPlayer.Get(), WidgetClass)
+			: CreateWidget<USQLUIBaseWidget>(World, WidgetClass);
+
+		if (!CreatedWidget)
+		{
+			AddSQLUIWidgetConstructionError(
+				Result,
+				FString::Printf(
+					TEXT("SQLUI widget construction failed to create widget '%s' using class '%s'."),
+					*PreparedNode.LayoutNode.WidgetId,
+					*WidgetClass->GetPathName()));
+			return Result;
+		}
+
+		FSQLUIWidgetInitializeParams InitializeParams;
+		InitializeParams.RuntimeContext = Request.RuntimeContext;
+		InitializeParams.LayoutNode = PreparedNode.LayoutNode;
+		CreatedWidget->InitializeSQLUIWidget(InitializeParams);
+
+		FSQLUICreatedWidgetRecord CreatedWidgetRecord;
+		CreatedWidgetRecord.WidgetId = PreparedNode.LayoutNode.WidgetId;
+		CreatedWidgetRecord.LayoutNode = PreparedNode.LayoutNode;
+		CreatedWidgetRecord.WidgetClass = WidgetClass;
+		CreatedWidgetRecord.Widget = CreatedWidget;
+
+		Result.CreatedWidgets.Add(CreatedWidgetRecord);
+		Result.CreatedWidgetMap.Add(CreatedWidgetRecord.WidgetId, CreatedWidget);
+
+		if (!Request.RootWidgetId.IsEmpty() && CreatedWidgetRecord.WidgetId == Request.RootWidgetId)
+		{
+			Result.RootWidget = CreatedWidget;
+		}
+	}
+
+	Result.bSucceeded = true;
+	return Result;
+}

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Public/Construction/SQLUIWidgetConstructor.h
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Public/Construction/SQLUIWidgetConstructor.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/PlayerController.h"
+#include "Layout/SQLUILayoutWidgetFactory.h"
+#include "UObject/Object.h"
+
+#include "SQLUIWidgetConstructor.generated.h"
+
+USTRUCT(BlueprintType)
+struct SQLUIWIDGETS_API FSQLUIWidgetConstructionRequest
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Construction")
+	TArray<FSQLUIPreparedWidgetBuildNode> PreparedNodes;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Construction")
+	FString RootWidgetId;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Transient, Category = "SQLUI|Widget Construction")
+	TObjectPtr<USQLUIRuntimeContext> RuntimeContext = nullptr;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Transient, Category = "SQLUI|Widget Construction")
+	TObjectPtr<APlayerController> OwningPlayer = nullptr;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Transient, Category = "SQLUI|Widget Construction")
+	TObjectPtr<UObject> WorldContextObject = nullptr;
+};
+
+USTRUCT(BlueprintType)
+struct SQLUIWIDGETS_API FSQLUICreatedWidgetRecord
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Construction")
+	FString WidgetId;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Construction")
+	FSQLUILayoutNode LayoutNode;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Construction")
+	TSubclassOf<USQLUIBaseWidget> WidgetClass = nullptr;
+
+	UPROPERTY(BlueprintReadWrite, Transient, Category = "SQLUI|Widget Construction")
+	TObjectPtr<USQLUIBaseWidget> Widget = nullptr;
+};
+
+USTRUCT(BlueprintType)
+struct SQLUIWIDGETS_API FSQLUIWidgetConstructionResult
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Construction")
+	bool bSucceeded = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Construction")
+	FString ErrorMessage;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Construction")
+	TArray<FString> Errors;
+
+	UPROPERTY(BlueprintReadWrite, Transient, Category = "SQLUI|Widget Construction")
+	TObjectPtr<USQLUIBaseWidget> RootWidget = nullptr;
+
+	UPROPERTY(BlueprintReadWrite, Transient, Category = "SQLUI|Widget Construction")
+	TArray<FSQLUICreatedWidgetRecord> CreatedWidgets;
+
+	UPROPERTY(BlueprintReadWrite, Transient, Category = "SQLUI|Widget Construction")
+	TMap<FString, USQLUIBaseWidget*> CreatedWidgetMap;
+};
+
+UCLASS(BlueprintType)
+class SQLUIWIDGETS_API USQLUIWidgetConstructor : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	UFUNCTION(BlueprintCallable, Category = "SQLUI|Widget Construction")
+	FSQLUIWidgetConstructionResult ConstructWidgets(const FSQLUIWidgetConstructionRequest& Request) const;
+};


### PR DESCRIPTION
Summary
- Added SQLUI widget construction request/result types
- Added created widget record data
- Added minimal widget constructor skeleton
- Creates USQLUIBaseWidget instances from prepared widget build nodes
- Initializes created widgets with runtime context and layout node data
- Keeps the work focused inside SQLUIWidgets

Validation
- Ran git diff --check
- Built JerryRiggedEditor Win64 Development successfully

Notes
- Does not attach widgets to the viewport
- Does not build the full recursive widget tree yet
- Does not apply bindings or execute actions
- Does not query SQLite/database systems
- Does not touch host-game or SQLUISamples code