### PR TITLE
Add SQLUI widget property application skeleton

### DIFF
--- a/Plugins/SQLUI/Source/SQLUIWidgets/Private/Properties/SQLUIWidgetPropertyApplier.cpp
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Private/Properties/SQLUIWidgetPropertyApplier.cpp
@@ -1,0 +1,131 @@
+#include "Properties/SQLUIWidgetPropertyApplier.h"
+
+#include "Widgets/SQLUIBaseWidget.h"
+
+namespace
+{
+void AddSQLUIWidgetPropertyApplyError(
+	FSQLUIWidgetPropertyApplyResult& Result,
+	const FString& WidgetId,
+	const FString& PropertyName,
+	const FString& ErrorMessage,
+	const bool bUnsupportedProperty = false)
+{
+	FSQLUIWidgetPropertyApplyError Error;
+	Error.WidgetId = WidgetId;
+	Error.PropertyName = PropertyName;
+	Error.ErrorMessage = ErrorMessage;
+	Error.bUnsupportedProperty = bUnsupportedProperty;
+
+	Result.bSucceeded = false;
+	Result.Errors.Add(Error);
+
+	if (Result.ErrorMessage.IsEmpty())
+	{
+		Result.ErrorMessage = ErrorMessage;
+	}
+}
+
+void AddSQLUIWidgetPropertyApplyWarning(
+	FSQLUIWidgetPropertyApplyResult& Result,
+	const FString& WidgetId,
+	const FString& PropertyName,
+	const FString& WarningMessage)
+{
+	Result.Warnings.Add(FString::Printf(
+		TEXT("Widget '%s' property '%s': %s"),
+		*WidgetId,
+		*PropertyName,
+		*WarningMessage));
+}
+
+USQLUIBaseWidget* FindSQLUIPropertyApplyWidget(
+	const FSQLUIWidgetPropertyApplyRequest& Request,
+	const FString& WidgetId)
+{
+	USQLUIBaseWidget* const* CreatedWidget = Request.CreatedWidgetMap.Find(WidgetId);
+	return CreatedWidget ? *CreatedWidget : nullptr;
+}
+
+FString MakeSQLUIAppliedPropertyName(const FString& WidgetId, const FString& PropertyName)
+{
+	return FString::Printf(TEXT("%s.%s"), *WidgetId, *PropertyName);
+}
+}
+
+FSQLUIWidgetPropertyApplyResult USQLUIWidgetPropertyApplier::ApplyProperties(
+	const FSQLUIWidgetPropertyApplyRequest& Request) const
+{
+	FSQLUIWidgetPropertyApplyResult Result;
+
+	for (int32 NodeIndex = 0; NodeIndex < Request.LayoutNodes.Num(); ++NodeIndex)
+	{
+		const FSQLUILayoutNode& LayoutNode = Request.LayoutNodes[NodeIndex];
+		if (LayoutNode.WidgetId.IsEmpty())
+		{
+			AddSQLUIWidgetPropertyApplyError(
+				Result,
+				FString(),
+				FString(),
+				FString::Printf(TEXT("SQLUI widget property application found a layout node without a widget id at index %d."), NodeIndex));
+			continue;
+		}
+
+		USQLUIBaseWidget* Widget = FindSQLUIPropertyApplyWidget(Request, LayoutNode.WidgetId);
+		if (!IsValid(Widget))
+		{
+			AddSQLUIWidgetPropertyApplyError(
+				Result,
+				LayoutNode.WidgetId,
+				FString(),
+				FString::Printf(
+					TEXT("SQLUI widget property application layout node '%s' does not have a valid created widget."),
+					*LayoutNode.WidgetId));
+			continue;
+		}
+
+		for (const TPair<FString, FString>& PropertyPair : LayoutNode.Properties)
+		{
+			FString ApplyMessage;
+			bool bUnsupportedProperty = false;
+			const bool bApplied = Widget->ApplySQLUIWidgetProperty(
+				PropertyPair.Key,
+				PropertyPair.Value,
+				ApplyMessage,
+				bUnsupportedProperty);
+
+			if (bApplied)
+			{
+				Result.AppliedPropertyNames.Add(MakeSQLUIAppliedPropertyName(LayoutNode.WidgetId, PropertyPair.Key));
+				continue;
+			}
+
+			if (ApplyMessage.IsEmpty())
+			{
+				ApplyMessage = FString::Printf(
+					TEXT("SQLUI widget property '%s' could not be applied."),
+					*PropertyPair.Key);
+			}
+
+			if (bUnsupportedProperty && !Request.bFailOnUnsupportedProperties)
+			{
+				AddSQLUIWidgetPropertyApplyWarning(
+					Result,
+					LayoutNode.WidgetId,
+					PropertyPair.Key,
+					ApplyMessage);
+				continue;
+			}
+
+			AddSQLUIWidgetPropertyApplyError(
+				Result,
+				LayoutNode.WidgetId,
+				PropertyPair.Key,
+				ApplyMessage,
+				bUnsupportedProperty);
+		}
+	}
+
+	Result.bSucceeded = Result.Errors.IsEmpty();
+	return Result;
+}

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIBaseWidget.cpp
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIBaseWidget.cpp
@@ -1,5 +1,32 @@
 #include "Widgets/SQLUIBaseWidget.h"
 
+namespace
+{
+bool TryParseSQLUIWidgetBool(const FString& Value, bool& bOutValue)
+{
+	const FString NormalizedValue = Value.TrimStartAndEnd().ToLower();
+	if (NormalizedValue == TEXT("true")
+		|| NormalizedValue == TEXT("1")
+		|| NormalizedValue == TEXT("yes")
+		|| NormalizedValue == TEXT("on"))
+	{
+		bOutValue = true;
+		return true;
+	}
+
+	if (NormalizedValue == TEXT("false")
+		|| NormalizedValue == TEXT("0")
+		|| NormalizedValue == TEXT("no")
+		|| NormalizedValue == TEXT("off"))
+	{
+		bOutValue = false;
+		return true;
+	}
+
+	return false;
+}
+}
+
 void USQLUIBaseWidget::InitializeSQLUIWidget(const FSQLUIWidgetInitializeParams& InInitializeParams)
 {
 	InitializeParams = InInitializeParams;
@@ -33,6 +60,22 @@ FString USQLUIBaseWidget::GetSQLUIWidgetTypeKey() const
 	return InitializeParams.LayoutNode.WidgetTypeKey;
 }
 
+bool USQLUIBaseWidget::ApplySQLUIWidgetProperty(
+	const FString& PropertyName,
+	const FString& PropertyValue,
+	FString& OutFailureMessage,
+	bool& bOutUnsupportedProperty)
+{
+	OutFailureMessage.Reset();
+	bOutUnsupportedProperty = false;
+
+	return NativeApplySQLUIWidgetProperty(
+		PropertyName,
+		PropertyValue,
+		OutFailureMessage,
+		bOutUnsupportedProperty);
+}
+
 bool USQLUIBaseWidget::CanAcceptSQLUIChildWidget(
 	const USQLUIBaseWidget* ChildWidget,
 	const FSQLUILayoutNode& ChildLayoutNode) const
@@ -42,4 +85,34 @@ bool USQLUIBaseWidget::CanAcceptSQLUIChildWidget(
 
 void USQLUIBaseWidget::NativeOnSQLUIWidgetInitialized()
 {
+}
+
+bool USQLUIBaseWidget::NativeApplySQLUIWidgetProperty(
+	const FString& PropertyName,
+	const FString& PropertyValue,
+	FString& OutFailureMessage,
+	bool& bOutUnsupportedProperty)
+{
+	if (PropertyName == TEXT("IsEnabled"))
+	{
+		bool bParsedValue = false;
+		if (!TryParseSQLUIWidgetBool(PropertyValue, bParsedValue))
+		{
+			OutFailureMessage = FString::Printf(
+				TEXT("SQLUI widget property '%s' expected a boolean value but received '%s'."),
+				*PropertyName,
+				*PropertyValue);
+			return false;
+		}
+
+		SetIsEnabled(bParsedValue);
+		return true;
+	}
+
+	bOutUnsupportedProperty = true;
+	OutFailureMessage = FString::Printf(
+		TEXT("SQLUI widget property '%s' is not supported by widget '%s'."),
+		*PropertyName,
+		*GetClass()->GetName());
+	return false;
 }

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIFilterBox.cpp
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIFilterBox.cpp
@@ -19,3 +19,22 @@ void USQLUIFilterBox::ClearFilterText()
 void USQLUIFilterBox::NativeOnFilterTextChanged(const FText& InFilterText)
 {
 }
+
+bool USQLUIFilterBox::NativeApplySQLUIWidgetProperty(
+	const FString& PropertyName,
+	const FString& PropertyValue,
+	FString& OutFailureMessage,
+	bool& bOutUnsupportedProperty)
+{
+	if (PropertyName == TEXT("FilterText"))
+	{
+		SetFilterText(FText::FromString(PropertyValue));
+		return true;
+	}
+
+	return Super::NativeApplySQLUIWidgetProperty(
+		PropertyName,
+		PropertyValue,
+		OutFailureMessage,
+		bOutUnsupportedProperty);
+}

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIListItemWidget.cpp
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIListItemWidget.cpp
@@ -14,3 +14,32 @@ FSQLUIListItemData USQLUIListItemWidget::GetListItemData() const
 void USQLUIListItemWidget::NativeOnListItemDataChanged()
 {
 }
+
+bool USQLUIListItemWidget::NativeApplySQLUIWidgetProperty(
+	const FString& PropertyName,
+	const FString& PropertyValue,
+	FString& OutFailureMessage,
+	bool& bOutUnsupportedProperty)
+{
+	if (PropertyName == TEXT("ItemId"))
+	{
+		FSQLUIListItemData UpdatedListItemData = GetListItemData();
+		UpdatedListItemData.ItemId = PropertyValue;
+		SetListItemData(UpdatedListItemData);
+		return true;
+	}
+
+	if (PropertyName == TEXT("DisplayText"))
+	{
+		FSQLUIListItemData UpdatedListItemData = GetListItemData();
+		UpdatedListItemData.DisplayText = FText::FromString(PropertyValue);
+		SetListItemData(UpdatedListItemData);
+		return true;
+	}
+
+	return Super::NativeApplySQLUIWidgetProperty(
+		PropertyName,
+		PropertyValue,
+		OutFailureMessage,
+		bOutUnsupportedProperty);
+}

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Public/Properties/SQLUIWidgetPropertyApplier.h
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Public/Properties/SQLUIWidgetPropertyApplier.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Properties/SQLUIWidgetPropertyTypes.h"
+#include "UObject/Object.h"
+
+#include "SQLUIWidgetPropertyApplier.generated.h"
+
+UCLASS(BlueprintType)
+class SQLUIWIDGETS_API USQLUIWidgetPropertyApplier : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	UFUNCTION(BlueprintCallable, Category = "SQLUI|Widget Properties")
+	FSQLUIWidgetPropertyApplyResult ApplyProperties(const FSQLUIWidgetPropertyApplyRequest& Request) const;
+};

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Public/Properties/SQLUIWidgetPropertyTypes.h
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Public/Properties/SQLUIWidgetPropertyTypes.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Layout/SQLUILayoutTypes.h"
+#include "Widgets/SQLUIBaseWidget.h"
+
+#include "SQLUIWidgetPropertyTypes.generated.h"
+
+USTRUCT(BlueprintType)
+struct SQLUIWIDGETS_API FSQLUIWidgetPropertyApplyError
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Properties")
+	FString WidgetId;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Properties")
+	FString PropertyName;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Properties")
+	FString ErrorMessage;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Properties")
+	bool bUnsupportedProperty = false;
+};
+
+USTRUCT(BlueprintType)
+struct SQLUIWIDGETS_API FSQLUIWidgetPropertyApplyRequest
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Properties")
+	TArray<FSQLUILayoutNode> LayoutNodes;
+
+	UPROPERTY(BlueprintReadWrite, Transient, Category = "SQLUI|Widget Properties")
+	TMap<FString, USQLUIBaseWidget*> CreatedWidgetMap;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Properties")
+	bool bFailOnUnsupportedProperties = false;
+};
+
+USTRUCT(BlueprintType)
+struct SQLUIWIDGETS_API FSQLUIWidgetPropertyApplyResult
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Properties")
+	bool bSucceeded = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Properties")
+	FString ErrorMessage;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Properties")
+	TArray<FSQLUIWidgetPropertyApplyError> Errors;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Properties")
+	TArray<FString> Warnings;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Properties")
+	TArray<FString> AppliedPropertyNames;
+};

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIBaseWidget.h
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIBaseWidget.h
@@ -43,12 +43,24 @@ public:
 	UFUNCTION(BlueprintPure, Category = "SQLUI|Widget")
 	FString GetSQLUIWidgetTypeKey() const;
 
+	bool ApplySQLUIWidgetProperty(
+		const FString& PropertyName,
+		const FString& PropertyValue,
+		FString& OutFailureMessage,
+		bool& bOutUnsupportedProperty);
+
 	virtual bool CanAcceptSQLUIChildWidget(
 		const USQLUIBaseWidget* ChildWidget,
 		const FSQLUILayoutNode& ChildLayoutNode) const;
 
 protected:
 	virtual void NativeOnSQLUIWidgetInitialized();
+
+	virtual bool NativeApplySQLUIWidgetProperty(
+		const FString& PropertyName,
+		const FString& PropertyValue,
+		FString& OutFailureMessage,
+		bool& bOutUnsupportedProperty);
 
 private:
 	UPROPERTY(Transient)

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIFilterBox.h
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIFilterBox.h
@@ -22,6 +22,11 @@ public:
 
 protected:
 	virtual void NativeOnFilterTextChanged(const FText& InFilterText);
+	virtual bool NativeApplySQLUIWidgetProperty(
+		const FString& PropertyName,
+		const FString& PropertyValue,
+		FString& OutFailureMessage,
+		bool& bOutUnsupportedProperty) override;
 
 private:
 	UPROPERTY(Transient, BlueprintReadOnly, Category = "SQLUI|Filter", meta = (AllowPrivateAccess = "true"))

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIListItemWidget.h
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIListItemWidget.h
@@ -20,6 +20,11 @@ public:
 
 protected:
 	virtual void NativeOnListItemDataChanged();
+	virtual bool NativeApplySQLUIWidgetProperty(
+		const FString& PropertyName,
+		const FString& PropertyValue,
+		FString& OutFailureMessage,
+		bool& bOutUnsupportedProperty) override;
 
 private:
 	UPROPERTY(Transient, BlueprintReadOnly, Category = "SQLUI|List", meta = (AllowPrivateAccess = "true"))


### PR DESCRIPTION
Summary
- Added SQLUI widget property application request/result types
- Added widget property applier skeleton
- Added base widget property hook
- Added simple property application for FilterBox and ListItemWidget
- Keeps unsupported properties as warnings by default

Validation
- Ran git diff --check
- Built JerryRiggedEditor Win64 Development successfully

Notes
- Does not apply bindings
- Does not execute actions
- Does not query SQLite/database systems
- Does not attach widgets or mutate viewport/world
- Does not touch host-game or SQLUISamples code