### PR TITLE
Add SQLUISamples pipeline smoke test runner

### DIFF
--- a/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISamplePipelineSmokeTestActor.cpp
+++ b/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISamplePipelineSmokeTestActor.cpp
@@ -2,14 +2,6 @@
 
 #include "SQLUISamplesModule.h"
 #include "Engine/World.h"
-#include "GameFramework/PlayerController.h"
-#include "Layout/SQLUILayoutTypes.h"
-#include "Pipeline/SQLUIRuntimeWidgetPipeline.h"
-#include "Runtime/SQLUIRuntimeContext.h"
-#include "Variables/SQLUIVariableStore.h"
-#include "Variables/SQLUIVariableTypes.h"
-#include "WidgetCatalog/SQLUIWidgetCatalog.h"
-#include "WidgetCatalog/SQLUIWidgetCatalogRegistrar.h"
 
 namespace
 {
@@ -31,35 +23,6 @@ const TCHAR* SQLUISamplePipelineSmokeTestStepStatusToString(
 	}
 }
 
-FSQLUILayoutDocument MakeSQLUISamplePipelineSmokeTestDocument()
-{
-	FSQLUILayoutDocument Document;
-	Document.Version.SchemaVersion = 1;
-	Document.Version.Revision = 1;
-	Document.Version.Label = TEXT("SQLUI Sample Pipeline Smoke Test");
-	Document.Metadata.LayoutId = TEXT("sqlui.sample.pipeline.smoke-test");
-	Document.Metadata.DisplayName = TEXT("SQLUI Sample Pipeline Smoke Test");
-	Document.Metadata.Description = TEXT("Minimal in-memory SQLUI runtime widget pipeline smoke test layout.");
-	Document.Metadata.CreatedBy = TEXT("SQLUISamples");
-	Document.RootWidgetId = TEXT("SQLUI.Sample.FilterRoot");
-
-	FSQLUILayoutBinding FilterTextBinding;
-	FilterTextBinding.BindingId = TEXT("SQLUI.Sample.FilterTextBinding");
-	FilterTextBinding.TargetProperty = TEXT("FilterText");
-	FilterTextBinding.SourceKey = TEXT("Variable");
-	FilterTextBinding.SourcePath = TEXT("Sample.FilterText");
-
-	FSQLUILayoutNode RootNode;
-	RootNode.WidgetId = Document.RootWidgetId;
-	RootNode.WidgetTypeKey = FSQLUIWidgetTypeKeys::FilterBox().Value;
-	RootNode.Properties.Add(TEXT("FilterText"), TEXT("Smoke test"));
-	RootNode.Properties.Add(TEXT("IsEnabled"), TEXT("true"));
-	RootNode.Bindings.Add(FilterTextBinding);
-
-	Document.Nodes.Add(RootNode);
-	return Document;
-}
-
 void LogSQLUISamplePipelineSmokeTestErrors(const TArray<FString>& Messages)
 {
 	for (const FString& Message : Messages)
@@ -76,19 +39,19 @@ void LogSQLUISamplePipelineSmokeTestWarnings(const TArray<FString>& Messages)
 	}
 }
 
-void LogSQLUISamplePipelineSmokeTestResult(const FSQLUIRuntimeWidgetPipelineResult& Result)
+void LogSQLUISamplePipelineSmokeTestResult(const FSQLUISampleSmokeTestResult& Result)
 {
 	UE_LOG(
 		LogSQLUISamples,
 		Log,
 		TEXT("SQLUI sample pipeline smoke test root widget valid: %s"),
-		IsValid(Result.RootWidget.Get()) ? TEXT("true") : TEXT("false"));
+		Result.bRootWidgetValid ? TEXT("true") : TEXT("false"));
 
 	UE_LOG(
 		LogSQLUISamples,
 		Log,
 		TEXT("SQLUI sample pipeline smoke test created widget count: %d"),
-		Result.CreatedWidgets.Num());
+		Result.CreatedWidgetCount);
 
 	for (const FSQLUIRuntimeWidgetPipelineStepResult& StepResult : Result.StepResults)
 	{
@@ -122,68 +85,14 @@ void ASQLUISamplePipelineSmokeTestActor::BeginPlay()
 
 void ASQLUISamplePipelineSmokeTestActor::RunSmokeTest()
 {
-	USQLUIWidgetCatalog* WidgetCatalog = NewObject<USQLUIWidgetCatalog>(this);
-	if (!IsValid(WidgetCatalog))
+	FSQLUISampleSmokeTestRequest Request = SmokeTestRequest;
+	if (!IsValid(Request.OwningPlayer.Get()) && GetWorld())
 	{
-		UE_LOG(LogSQLUISamples, Error, TEXT("SQLUI sample pipeline smoke test failed: could not create widget catalog."));
-		return;
+		Request.OwningPlayer = GetWorld()->GetFirstPlayerController();
 	}
 
-	if (!USQLUIWidgetCatalogRegistrar::RegisterDefaultSQLUIWidgets(WidgetCatalog))
-	{
-		UE_LOG(LogSQLUISamples, Error, TEXT("SQLUI sample pipeline smoke test failed: could not register default widget catalog entries."));
-		return;
-	}
-
-	USQLUIVariableStore* VariableStore = NewObject<USQLUIVariableStore>(this);
-	if (!IsValid(VariableStore))
-	{
-		UE_LOG(LogSQLUISamples, Error, TEXT("SQLUI sample pipeline smoke test failed: could not create variable store."));
-		return;
-	}
-
-	FSQLUIVariableKey FilterTextKey;
-	FilterTextKey.Name = TEXT("Sample.FilterText");
-
-	FSQLUIVariableValue FilterTextValue;
-	FilterTextValue.Type = ESQLUIVariableValueType::String;
-	FilterTextValue.StringValue = TEXT("Smoke test variable");
-	VariableStore->SetVariable(FilterTextKey, FilterTextValue);
-
-	USQLUIRuntimeContext* RuntimeContext = NewObject<USQLUIRuntimeContext>(this);
-	if (!IsValid(RuntimeContext))
-	{
-		UE_LOG(LogSQLUISamples, Error, TEXT("SQLUI sample pipeline smoke test failed: could not create runtime context."));
-		return;
-	}
-
-	FSQLUIRuntimeContextSettings RuntimeContextSettings;
-	RuntimeContextSettings.VariableStore = VariableStore;
-	RuntimeContextSettings.WidgetCatalog = WidgetCatalog;
-	RuntimeContext->Initialize(RuntimeContextSettings);
-
-	if (!RuntimeContext->IsInitialized())
-	{
-		UE_LOG(LogSQLUISamples, Error, TEXT("SQLUI sample pipeline smoke test failed: runtime context did not initialize."));
-		return;
-	}
-
-	USQLUIRuntimeWidgetPipeline* Pipeline = NewObject<USQLUIRuntimeWidgetPipeline>(this);
-	if (!IsValid(Pipeline))
-	{
-		UE_LOG(LogSQLUISamples, Error, TEXT("SQLUI sample pipeline smoke test failed: could not create runtime widget pipeline."));
-		return;
-	}
-
-	FSQLUIRuntimeWidgetPipelineRequest Request;
-	Request.Document = MakeSQLUISamplePipelineSmokeTestDocument();
-	Request.RuntimeContext = RuntimeContext;
-	Request.WidgetCatalogOverride = WidgetCatalog;
-	Request.WorldContextObject = this;
-	Request.OwningPlayer = GetWorld() ? GetWorld()->GetFirstPlayerController() : nullptr;
-	Request.bExecuteActions = false;
-
-	const FSQLUIRuntimeWidgetPipelineResult Result = Pipeline->RunPipeline(Request);
+	const FSQLUISampleSmokeTestResult Result =
+		USQLUISampleSmokeTestRunner::RunSmokeTest(this, Request);
 	if (Result.bSucceeded)
 	{
 		UE_LOG(LogSQLUISamples, Log, TEXT("SQLUI sample pipeline smoke test succeeded."));

--- a/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleSmokeTestRunner.cpp
+++ b/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleSmokeTestRunner.cpp
@@ -1,0 +1,190 @@
+#include "SQLUISampleSmokeTestRunner.h"
+
+#include "Layout/SQLUILayoutTypes.h"
+#include "Runtime/SQLUIRuntimeContext.h"
+#include "Variables/SQLUIVariableStore.h"
+#include "Variables/SQLUIVariableTypes.h"
+#include "WidgetCatalog/SQLUIWidgetCatalog.h"
+#include "WidgetCatalog/SQLUIWidgetCatalogRegistrar.h"
+#include "UObject/Package.h"
+
+namespace
+{
+const TCHAR* SQLUISampleSmokeTestFilterVariableName = TEXT("Sample.FilterText");
+
+void AddSQLUISampleSmokeTestError(
+	FSQLUISampleSmokeTestResult& Result,
+	const FString& ErrorMessage)
+{
+	if (!ErrorMessage.IsEmpty())
+	{
+		Result.Errors.Add(ErrorMessage);
+	}
+
+	if (Result.ErrorMessage.IsEmpty())
+	{
+		Result.ErrorMessage = ErrorMessage;
+	}
+}
+
+UObject* ResolveSQLUISampleSmokeTestOuter(
+	UObject* WorldContextObject,
+	const FSQLUISampleSmokeTestRequest& Request)
+{
+	if (IsValid(WorldContextObject))
+	{
+		return WorldContextObject;
+	}
+
+	if (IsValid(Request.OwningPlayer.Get()))
+	{
+		return Request.OwningPlayer.Get();
+	}
+
+	return GetTransientPackage();
+}
+
+FSQLUILayoutDocument MakeSQLUISampleSmokeTestDocument(
+	const FSQLUISampleSmokeTestRequest& Request)
+{
+	FSQLUILayoutDocument Document;
+	Document.Version.SchemaVersion = 1;
+	Document.Version.Revision = 1;
+	Document.Version.Label = TEXT("SQLUI Sample Pipeline Smoke Test");
+	Document.Metadata.LayoutId = TEXT("sqlui.sample.pipeline.smoke-test");
+	Document.Metadata.DisplayName = TEXT("SQLUI Sample Pipeline Smoke Test");
+	Document.Metadata.Description = TEXT("Minimal in-memory SQLUI runtime widget pipeline smoke test layout.");
+	Document.Metadata.CreatedBy = TEXT("SQLUISamples");
+	Document.RootWidgetId = TEXT("SQLUI.Sample.FilterRoot");
+
+	FSQLUILayoutBinding FilterTextBinding;
+	FilterTextBinding.BindingId = TEXT("SQLUI.Sample.FilterTextBinding");
+	FilterTextBinding.TargetProperty = TEXT("FilterText");
+	FilterTextBinding.SourceKey = TEXT("Variable");
+	FilterTextBinding.SourcePath = SQLUISampleSmokeTestFilterVariableName;
+
+	FSQLUILayoutNode RootNode;
+	RootNode.WidgetId = Document.RootWidgetId;
+	RootNode.WidgetTypeKey = FSQLUIWidgetTypeKeys::FilterBox().Value;
+	RootNode.Properties.Add(TEXT("FilterText"), Request.SampleFilterText);
+	RootNode.Properties.Add(TEXT("IsEnabled"), TEXT("true"));
+	RootNode.Bindings.Add(FilterTextBinding);
+
+	Document.Nodes.Add(RootNode);
+	return Document;
+}
+
+void SeedSQLUISampleSmokeTestVariables(
+	USQLUIVariableStore* VariableStore,
+	const FSQLUISampleSmokeTestRequest& Request)
+{
+	if (!IsValid(VariableStore))
+	{
+		return;
+	}
+
+	FSQLUIVariableKey FilterTextKey;
+	FilterTextKey.Name = SQLUISampleSmokeTestFilterVariableName;
+
+	FSQLUIVariableValue FilterTextValue;
+	FilterTextValue.Type = ESQLUIVariableValueType::String;
+	FilterTextValue.StringValue = Request.SampleFilterVariableValue;
+	VariableStore->SetVariable(FilterTextKey, FilterTextValue);
+}
+
+FSQLUISampleSmokeTestResult MakeSQLUISampleSmokeTestResult(
+	const FSQLUIRuntimeWidgetPipelineResult& PipelineResult)
+{
+	FSQLUISampleSmokeTestResult Result;
+	Result.bSucceeded = PipelineResult.bSucceeded;
+	Result.ErrorMessage = PipelineResult.ErrorMessage;
+	Result.Errors = PipelineResult.Errors;
+	Result.Warnings = PipelineResult.Warnings;
+	Result.StepResults = PipelineResult.StepResults;
+	Result.CreatedWidgetCount = PipelineResult.CreatedWidgets.Num();
+	Result.RootWidget = PipelineResult.RootWidget;
+	Result.bRootWidgetValid = IsValid(Result.RootWidget.Get());
+	return Result;
+}
+}
+
+FSQLUISampleSmokeTestResult USQLUISampleSmokeTestRunner::RunSmokeTest(
+	UObject* WorldContextObject,
+	const FSQLUISampleSmokeTestRequest& Request)
+{
+	FSQLUISampleSmokeTestResult Result;
+	UObject* Outer = ResolveSQLUISampleSmokeTestOuter(WorldContextObject, Request);
+
+	USQLUIWidgetCatalog* WidgetCatalog = NewObject<USQLUIWidgetCatalog>(Outer);
+	if (!IsValid(WidgetCatalog))
+	{
+		AddSQLUISampleSmokeTestError(
+			Result,
+			TEXT("SQLUI sample pipeline smoke test failed: could not create widget catalog."));
+		return Result;
+	}
+
+	if (!USQLUIWidgetCatalogRegistrar::RegisterDefaultSQLUIWidgets(WidgetCatalog))
+	{
+		AddSQLUISampleSmokeTestError(
+			Result,
+			TEXT("SQLUI sample pipeline smoke test failed: could not register default widget catalog entries."));
+		return Result;
+	}
+
+	USQLUIVariableStore* VariableStore = NewObject<USQLUIVariableStore>(Outer);
+	if (!IsValid(VariableStore))
+	{
+		AddSQLUISampleSmokeTestError(
+			Result,
+			TEXT("SQLUI sample pipeline smoke test failed: could not create variable store."));
+		return Result;
+	}
+
+	SeedSQLUISampleSmokeTestVariables(VariableStore, Request);
+
+	USQLUIRuntimeContext* RuntimeContext = NewObject<USQLUIRuntimeContext>(Outer);
+	if (!IsValid(RuntimeContext))
+	{
+		AddSQLUISampleSmokeTestError(
+			Result,
+			TEXT("SQLUI sample pipeline smoke test failed: could not create runtime context."));
+		return Result;
+	}
+
+	FSQLUIRuntimeContextSettings RuntimeContextSettings;
+	RuntimeContextSettings.VariableStore = VariableStore;
+	RuntimeContextSettings.WidgetCatalog = WidgetCatalog;
+	RuntimeContext->Initialize(RuntimeContextSettings);
+
+	if (!RuntimeContext->IsInitialized())
+	{
+		AddSQLUISampleSmokeTestError(
+			Result,
+			TEXT("SQLUI sample pipeline smoke test failed: runtime context did not initialize."));
+		return Result;
+	}
+
+	USQLUIRuntimeWidgetPipeline* Pipeline = NewObject<USQLUIRuntimeWidgetPipeline>(Outer);
+	if (!IsValid(Pipeline))
+	{
+		AddSQLUISampleSmokeTestError(
+			Result,
+			TEXT("SQLUI sample pipeline smoke test failed: could not create runtime widget pipeline."));
+		return Result;
+	}
+
+	FSQLUIRuntimeWidgetPipelineRequest PipelineRequest;
+	PipelineRequest.Document = MakeSQLUISampleSmokeTestDocument(Request);
+	PipelineRequest.RuntimeContext = RuntimeContext;
+	PipelineRequest.WidgetCatalogOverride = WidgetCatalog;
+	PipelineRequest.WorldContextObject = WorldContextObject;
+	PipelineRequest.OwningPlayer = Request.OwningPlayer;
+	PipelineRequest.bApplyProperties = Request.bApplyProperties;
+	PipelineRequest.bApplyBindings = Request.bApplyBindings;
+	PipelineRequest.bApplyActions = Request.bApplyActions;
+	PipelineRequest.bExecuteActions = Request.bExecuteActions;
+	PipelineRequest.bStopOnOptionalStepFailure = Request.bStopOnOptionalStepFailure;
+
+	return MakeSQLUISampleSmokeTestResult(Pipeline->RunPipeline(PipelineRequest));
+}

--- a/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISamplePipelineSmokeTestActor.h
+++ b/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISamplePipelineSmokeTestActor.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
+#include "SQLUISampleSmokeTestRunner.h"
 
 #include "SQLUISamplePipelineSmokeTestActor.generated.h"
 
@@ -22,4 +23,7 @@ protected:
 public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
 	bool bRunSmokeTestOnBeginPlay = true;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FSQLUISampleSmokeTestRequest SmokeTestRequest;
 };

--- a/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISampleSmokeTestRunner.h
+++ b/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISampleSmokeTestRunner.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Pipeline/SQLUIRuntimeWidgetPipeline.h"
+#include "UObject/Object.h"
+
+#include "SQLUISampleSmokeTestRunner.generated.h"
+
+class APlayerController;
+class USQLUIBaseWidget;
+
+USTRUCT(BlueprintType)
+struct SQLUISAMPLES_API FSQLUISampleSmokeTestRequest
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadWrite, Transient, Category = "SQLUI|Samples")
+	TObjectPtr<APlayerController> OwningPlayer = nullptr;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bApplyProperties = true;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bApplyBindings = true;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bApplyActions = true;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bExecuteActions = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bStopOnOptionalStepFailure = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FString SampleFilterText = TEXT("Smoke test");
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FString SampleFilterVariableValue = TEXT("Smoke test variable");
+};
+
+USTRUCT(BlueprintType)
+struct SQLUISAMPLES_API FSQLUISampleSmokeTestResult
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bSucceeded = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FString ErrorMessage;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	TArray<FString> Errors;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	TArray<FString> Warnings;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	TArray<FSQLUIRuntimeWidgetPipelineStepResult> StepResults;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	int32 CreatedWidgetCount = 0;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bRootWidgetValid = false;
+
+	UPROPERTY(BlueprintReadWrite, Transient, Category = "SQLUI|Samples")
+	TObjectPtr<USQLUIBaseWidget> RootWidget = nullptr;
+};
+
+UCLASS(BlueprintType)
+class SQLUISAMPLES_API USQLUISampleSmokeTestRunner : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	UFUNCTION(BlueprintCallable, Category = "SQLUI|Samples", meta = (WorldContext = "WorldContextObject"))
+	static FSQLUISampleSmokeTestResult RunSmokeTest(
+		UObject* WorldContextObject,
+		const FSQLUISampleSmokeTestRequest& Request);
+};


### PR DESCRIPTION
Summary
- Added SQLUISamples smoke test runner request/result types
- Moved reusable smoke-test setup and pipeline execution into a runner
- Updated the smoke test actor to call the runner
- Preserves actor logging behavior while avoiding duplicated sample logic
- Keeps the smoke test fully in-memory

Validation
- Ran git diff --check
- Built JerryRiggedEditor Win64 Development successfully

Notes
- Does not edit maps or Content
- Does not add widgets to viewport
- Does not query SQLite/database systems
- Does not add editor tooling
- Does not touch JerryRigged host code