### PR TITLE
Add SQLUISamples smoke test commandlet

### DIFF
--- a/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleSmokeTestCommandlet.cpp
+++ b/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleSmokeTestCommandlet.cpp
@@ -1,0 +1,177 @@
+#include "SQLUISampleSmokeTestCommandlet.h"
+
+#include "SQLUISamplesModule.h"
+#include "SQLUISampleSmokeTestRunner.h"
+#include "Engine/World.h"
+
+namespace
+{
+const TCHAR* SQLUISampleSmokeTestCommandletWorldName = TEXT("SQLUISampleSmokeTestCommandletWorld");
+
+const TCHAR* SQLUISampleSmokeTestStepStatusToString(
+	const ESQLUIRuntimeWidgetPipelineStepStatus Status)
+{
+	switch (Status)
+	{
+	case ESQLUIRuntimeWidgetPipelineStepStatus::NotRun:
+		return TEXT("NotRun");
+	case ESQLUIRuntimeWidgetPipelineStepStatus::Skipped:
+		return TEXT("Skipped");
+	case ESQLUIRuntimeWidgetPipelineStepStatus::Succeeded:
+		return TEXT("Succeeded");
+	case ESQLUIRuntimeWidgetPipelineStepStatus::Failed:
+		return TEXT("Failed");
+	default:
+		return TEXT("Unknown");
+	}
+}
+
+void LogSQLUISampleSmokeTestErrors(const TArray<FString>& Messages)
+{
+	for (const FString& Message : Messages)
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample smoke test error: %s"),
+			*Message);
+	}
+}
+
+void LogSQLUISampleSmokeTestWarnings(const TArray<FString>& Messages)
+{
+	for (const FString& Message : Messages)
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Warning,
+			TEXT("SQLUI sample smoke test warning: %s"),
+			*Message);
+	}
+}
+
+void LogSQLUISampleSmokeTestStepErrors(
+	const TCHAR* StepName,
+	const TArray<FString>& Messages)
+{
+	for (const FString& Message : Messages)
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample smoke test step '%s' error: %s"),
+			StepName,
+			*Message);
+	}
+}
+
+void LogSQLUISampleSmokeTestStepWarnings(
+	const TCHAR* StepName,
+	const TArray<FString>& Messages)
+{
+	for (const FString& Message : Messages)
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Warning,
+			TEXT("SQLUI sample smoke test step '%s' warning: %s"),
+			StepName,
+			*Message);
+	}
+}
+
+void LogSQLUISampleSmokeTestResult(const FSQLUISampleSmokeTestResult& Result)
+{
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample smoke test root widget valid: %s"),
+		Result.bRootWidgetValid ? TEXT("true") : TEXT("false"));
+
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample smoke test created widget count: %d"),
+		Result.CreatedWidgetCount);
+
+	LogSQLUISampleSmokeTestErrors(Result.Errors);
+	LogSQLUISampleSmokeTestWarnings(Result.Warnings);
+
+	for (const FSQLUIRuntimeWidgetPipelineStepResult& StepResult : Result.StepResults)
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Log,
+			TEXT("SQLUI sample smoke test step '%s': %s"),
+			*StepResult.StepName,
+			SQLUISampleSmokeTestStepStatusToString(StepResult.Status));
+
+		LogSQLUISampleSmokeTestStepErrors(
+			*StepResult.StepName,
+			StepResult.Errors);
+
+		LogSQLUISampleSmokeTestStepWarnings(
+			*StepResult.StepName,
+			StepResult.Warnings);
+	}
+}
+
+UWorld* CreateSQLUISampleSmokeTestCommandletWorld()
+{
+	return UWorld::CreateWorld(
+		EWorldType::Game,
+		false,
+		SQLUISampleSmokeTestCommandletWorldName);
+}
+
+void DestroySQLUISampleSmokeTestCommandletWorld(UWorld* World)
+{
+	if (World)
+	{
+		World->DestroyWorld(false);
+	}
+}
+}
+
+USQLUISampleSmokeTestCommandlet::USQLUISampleSmokeTestCommandlet()
+{
+	IsClient = false;
+	IsEditor = false;
+	IsServer = false;
+	LogToConsole = true;
+}
+
+int32 USQLUISampleSmokeTestCommandlet::Main(const FString& Params)
+{
+	UE_LOG(LogSQLUISamples, Log, TEXT("SQLUI sample smoke test commandlet started."));
+
+	UWorld* CommandletWorld = CreateSQLUISampleSmokeTestCommandletWorld();
+	if (!CommandletWorld)
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample smoke test commandlet could not create a transient world context."));
+		return 1;
+	}
+
+	FSQLUISampleSmokeTestResult Result;
+	{
+		FSQLUISampleSmokeTestRequest Request;
+		Result = USQLUISampleSmokeTestRunner::RunSmokeTest(CommandletWorld, Request);
+	}
+
+	if (Result.bSucceeded)
+	{
+		UE_LOG(LogSQLUISamples, Log, TEXT("SQLUI sample smoke test commandlet succeeded."));
+	}
+	else
+	{
+		UE_LOG(LogSQLUISamples, Error, TEXT("SQLUI sample smoke test commandlet failed."));
+	}
+
+	LogSQLUISampleSmokeTestResult(Result);
+	DestroySQLUISampleSmokeTestCommandletWorld(CommandletWorld);
+
+	return Result.bSucceeded ? 0 : 1;
+}

--- a/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISampleSmokeTestCommandlet.h
+++ b/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISampleSmokeTestCommandlet.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Commandlets/Commandlet.h"
+#include "CoreMinimal.h"
+
+#include "SQLUISampleSmokeTestCommandlet.generated.h"
+
+UCLASS()
+class SQLUISAMPLES_API USQLUISampleSmokeTestCommandlet : public UCommandlet
+{
+	GENERATED_BODY()
+
+public:
+	USQLUISampleSmokeTestCommandlet();
+
+	virtual int32 Main(const FString& Params) override;
+};


### PR DESCRIPTION
Summary
- Added SQLUISamples smoke test commandlet
- Runs the existing SQLUISamples smoke test runner from a headless commandlet entry point
- Logs success/failure, root widget validity, created widget count, errors, warnings, and pipeline step results
- Returns a nonzero result when the smoke test fails

Validation
- Ran git diff --check
- Built JerryRiggedEditor Win64 Development successfully
- Ran SQLUISampleSmokeTest commandlet successfully

Notes
- Does not edit maps or Content
- Does not add widgets to viewport
- Does not query SQLite/database systems
- Does not add editor UI/tooling
- Does not touch JerryRigged host code