### PR TITLE
Add SQLUISamples JSON layout fixture smoke test

### DIFF
--- a/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISamplePipelineSmokeTestActor.cpp
+++ b/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISamplePipelineSmokeTestActor.cpp
@@ -39,8 +39,55 @@ void LogSQLUISamplePipelineSmokeTestWarnings(const TArray<FString>& Messages)
 	}
 }
 
+void LogSQLUISamplePipelineSmokeTestJsonFixtureMessages(
+	const FSQLUILayoutValidationResult& Validation)
+{
+	for (const FString& Error : Validation.Errors)
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample pipeline smoke test JSON fixture validation error: %s"),
+			*Error);
+	}
+
+	for (const FString& Warning : Validation.Warnings)
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Warning,
+			TEXT("SQLUI sample pipeline smoke test JSON fixture validation warning: %s"),
+			*Warning);
+	}
+}
+
+void LogSQLUISamplePipelineSmokeTestJsonFixtureResult(
+	const FSQLUISampleSmokeTestResult& Result)
+{
+	if (!Result.bUsedJsonLayoutFixture)
+	{
+		return;
+	}
+
+	UE_LOG(LogSQLUISamples, Log, TEXT("SQLUI sample pipeline smoke test JSON fixture selected."));
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample pipeline smoke test JSON fixture parse %s."),
+		Result.bJsonLayoutFixtureParseSucceeded ? TEXT("succeeded") : TEXT("failed"));
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample pipeline smoke test JSON fixture validation %s."),
+		Result.bJsonLayoutFixtureValidationSucceeded ? TEXT("succeeded") : TEXT("failed"));
+
+	LogSQLUISamplePipelineSmokeTestJsonFixtureMessages(Result.JsonLayoutFixtureValidation);
+}
+
 void LogSQLUISamplePipelineSmokeTestResult(const FSQLUISampleSmokeTestResult& Result)
 {
+	LogSQLUISamplePipelineSmokeTestJsonFixtureResult(Result);
+
 	UE_LOG(
 		LogSQLUISamples,
 		Log,

--- a/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleSmokeTestCommandlet.cpp
+++ b/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleSmokeTestCommandlet.cpp
@@ -3,6 +3,7 @@
 #include "SQLUISamplesModule.h"
 #include "SQLUISampleSmokeTestRunner.h"
 #include "Engine/World.h"
+#include "Misc/Parse.h"
 
 namespace
 {
@@ -50,6 +51,51 @@ void LogSQLUISampleSmokeTestWarnings(const TArray<FString>& Messages)
 	}
 }
 
+void LogSQLUISampleSmokeTestJsonFixtureMessages(
+	const FSQLUILayoutValidationResult& Validation)
+{
+	for (const FString& Error : Validation.Errors)
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample smoke test JSON fixture validation error: %s"),
+			*Error);
+	}
+
+	for (const FString& Warning : Validation.Warnings)
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Warning,
+			TEXT("SQLUI sample smoke test JSON fixture validation warning: %s"),
+			*Warning);
+	}
+}
+
+void LogSQLUISampleSmokeTestJsonFixtureResult(
+	const FSQLUISampleSmokeTestResult& Result)
+{
+	if (!Result.bUsedJsonLayoutFixture)
+	{
+		return;
+	}
+
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample smoke test JSON fixture parse %s."),
+		Result.bJsonLayoutFixtureParseSucceeded ? TEXT("succeeded") : TEXT("failed"));
+
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample smoke test JSON fixture validation %s."),
+		Result.bJsonLayoutFixtureValidationSucceeded ? TEXT("succeeded") : TEXT("failed"));
+
+	LogSQLUISampleSmokeTestJsonFixtureMessages(Result.JsonLayoutFixtureValidation);
+}
+
 void LogSQLUISampleSmokeTestStepErrors(
 	const TCHAR* StepName,
 	const TArray<FString>& Messages)
@@ -82,6 +128,8 @@ void LogSQLUISampleSmokeTestStepWarnings(
 
 void LogSQLUISampleSmokeTestResult(const FSQLUISampleSmokeTestResult& Result)
 {
+	LogSQLUISampleSmokeTestJsonFixtureResult(Result);
+
 	UE_LOG(
 		LogSQLUISamples,
 		Log,
@@ -144,6 +192,15 @@ USQLUISampleSmokeTestCommandlet::USQLUISampleSmokeTestCommandlet()
 int32 USQLUISampleSmokeTestCommandlet::Main(const FString& Params)
 {
 	UE_LOG(LogSQLUISamples, Log, TEXT("SQLUI sample smoke test commandlet started."));
+	const bool bUseJsonLayoutFixture =
+		FParse::Param(*Params, TEXT("UseJsonLayoutFixture"))
+		|| FParse::Param(*Params, TEXT("JsonLayoutFixture"));
+
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample smoke test JSON fixture selected: %s"),
+		bUseJsonLayoutFixture ? TEXT("true") : TEXT("false"));
 
 	UWorld* CommandletWorld = CreateSQLUISampleSmokeTestCommandletWorld();
 	if (!CommandletWorld)
@@ -158,6 +215,7 @@ int32 USQLUISampleSmokeTestCommandlet::Main(const FString& Params)
 	FSQLUISampleSmokeTestResult Result;
 	{
 		FSQLUISampleSmokeTestRequest Request;
+		Request.bUseJsonLayoutFixture = bUseJsonLayoutFixture;
 		Result = USQLUISampleSmokeTestRunner::RunSmokeTest(CommandletWorld, Request);
 	}
 

--- a/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleSmokeTestRunner.cpp
+++ b/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleSmokeTestRunner.cpp
@@ -1,5 +1,6 @@
 #include "SQLUISampleSmokeTestRunner.h"
 
+#include "Layout/SQLUILayoutJson.h"
 #include "Layout/SQLUILayoutTypes.h"
 #include "Runtime/SQLUIRuntimeContext.h"
 #include "Variables/SQLUIVariableStore.h"
@@ -11,6 +12,69 @@
 namespace
 {
 const TCHAR* SQLUISampleSmokeTestFilterVariableName = TEXT("Sample.FilterText");
+
+struct FSQLUISampleLayoutJsonFixture
+{
+	static FString GetJsonString()
+	{
+		return TEXT(R"SQLUIJSON(
+{
+	"Version": {
+		"SchemaVersion": 1,
+		"Revision": 1,
+		"Label": "SQLUI Sample JSON Layout Fixture"
+	},
+	"Metadata": {
+		"LayoutId": "sqlui.sample.json-layout-fixture",
+		"DisplayName": "SQLUI Sample JSON Layout Fixture",
+		"Description": "Minimal SQLUISamples JSON layout fixture for the runtime widget pipeline smoke test.",
+		"CreatedBy": "SQLUISamples",
+		"CreatedAtUtc": "",
+		"UpdatedAtUtc": "",
+		"Tags": [],
+		"SearchMetadata": {}
+	},
+	"RootWidgetId": "SQLUI.Sample.Json.FilterRoot",
+	"Nodes": [
+		{
+			"WidgetId": "SQLUI.Sample.Json.FilterRoot",
+			"ParentWidgetId": "",
+			"WidgetTypeKey": "SQLUI.FilterBox",
+			"ChildWidgetIds": [],
+			"Properties": {
+				"FilterText": "Smoke test JSON fixture",
+				"IsEnabled": "true"
+			},
+			"Bindings": [
+				{
+					"BindingId": "SQLUI.Sample.Json.FilterTextBinding",
+					"TargetProperty": "FilterText",
+					"SourceKey": "Variable",
+					"SourcePath": "Sample.FilterText",
+					"TransformKey": "",
+					"Options": {}
+				}
+			],
+			"Actions": [],
+			"Tags": [],
+			"SearchMetadata": {}
+		}
+	],
+	"Properties": {}
+}
+)SQLUIJSON");
+	}
+};
+
+struct FSQLUISampleSmokeTestLayoutResult
+{
+	bool bSucceeded = true;
+	bool bUsedJsonLayoutFixture = false;
+	bool bJsonLayoutFixtureParseSucceeded = false;
+	bool bJsonLayoutFixtureValidationSucceeded = false;
+	FSQLUILayoutValidationResult JsonLayoutFixtureValidation;
+	FSQLUILayoutDocument Document;
+};
 
 void AddSQLUISampleSmokeTestError(
 	FSQLUISampleSmokeTestResult& Result,
@@ -74,6 +138,74 @@ FSQLUILayoutDocument MakeSQLUISampleSmokeTestDocument(
 	return Document;
 }
 
+bool IsSQLUISampleLayoutJsonParseFailureMessage(const FString& ErrorMessage)
+{
+	return ErrorMessage.Contains(TEXT("deserialize"), ESearchCase::IgnoreCase);
+}
+
+bool DidSQLUISampleLayoutJsonParseFail(const FSQLUILayoutValidationResult& Validation)
+{
+	for (const FString& Error : Validation.Errors)
+	{
+		if (IsSQLUISampleLayoutJsonParseFailureMessage(Error))
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+FSQLUISampleSmokeTestLayoutResult ResolveSQLUISampleSmokeTestLayoutDocument(
+	const FSQLUISampleSmokeTestRequest& Request)
+{
+	FSQLUISampleSmokeTestLayoutResult Result;
+	Result.bUsedJsonLayoutFixture = Request.bUseJsonLayoutFixture;
+
+	if (!Request.bUseJsonLayoutFixture)
+	{
+		Result.Document = MakeSQLUISampleSmokeTestDocument(Request);
+		return Result;
+	}
+
+	const bool bParsedAndValidated = FSQLUILayoutJson::FromJsonString(
+		FSQLUISampleLayoutJsonFixture::GetJsonString(),
+		Result.Document,
+		Result.JsonLayoutFixtureValidation);
+
+	Result.bJsonLayoutFixtureParseSucceeded =
+		!DidSQLUISampleLayoutJsonParseFail(Result.JsonLayoutFixtureValidation);
+	Result.bJsonLayoutFixtureValidationSucceeded =
+		Result.bJsonLayoutFixtureParseSucceeded && Result.JsonLayoutFixtureValidation.bIsValid;
+	Result.bSucceeded = bParsedAndValidated;
+	return Result;
+}
+
+void ApplySQLUISampleLayoutResult(
+	FSQLUISampleSmokeTestResult& Result,
+	const FSQLUISampleSmokeTestLayoutResult& LayoutResult)
+{
+	Result.bUsedJsonLayoutFixture = LayoutResult.bUsedJsonLayoutFixture;
+	Result.bJsonLayoutFixtureParseSucceeded = LayoutResult.bJsonLayoutFixtureParseSucceeded;
+	Result.bJsonLayoutFixtureValidationSucceeded = LayoutResult.bJsonLayoutFixtureValidationSucceeded;
+	Result.JsonLayoutFixtureValidation = LayoutResult.JsonLayoutFixtureValidation;
+}
+
+void AddSQLUISampleLayoutValidationMessages(
+	FSQLUISampleSmokeTestResult& Result,
+	const FSQLUILayoutValidationResult& Validation)
+{
+	for (const FString& Error : Validation.Errors)
+	{
+		AddSQLUISampleSmokeTestError(Result, Error);
+	}
+
+	for (const FString& Warning : Validation.Warnings)
+	{
+		Result.Warnings.Add(Warning);
+	}
+}
+
 void SeedSQLUISampleSmokeTestVariables(
 	USQLUIVariableStore* VariableStore,
 	const FSQLUISampleSmokeTestRequest& Request)
@@ -93,9 +225,11 @@ void SeedSQLUISampleSmokeTestVariables(
 }
 
 FSQLUISampleSmokeTestResult MakeSQLUISampleSmokeTestResult(
-	const FSQLUIRuntimeWidgetPipelineResult& PipelineResult)
+	const FSQLUIRuntimeWidgetPipelineResult& PipelineResult,
+	const FSQLUISampleSmokeTestLayoutResult& LayoutResult)
 {
 	FSQLUISampleSmokeTestResult Result;
+	ApplySQLUISampleLayoutResult(Result, LayoutResult);
 	Result.bSucceeded = PipelineResult.bSucceeded;
 	Result.ErrorMessage = PipelineResult.ErrorMessage;
 	Result.Errors = PipelineResult.Errors;
@@ -114,6 +248,20 @@ FSQLUISampleSmokeTestResult USQLUISampleSmokeTestRunner::RunSmokeTest(
 {
 	FSQLUISampleSmokeTestResult Result;
 	UObject* Outer = ResolveSQLUISampleSmokeTestOuter(WorldContextObject, Request);
+
+	const FSQLUISampleSmokeTestLayoutResult LayoutResult =
+		ResolveSQLUISampleSmokeTestLayoutDocument(Request);
+	ApplySQLUISampleLayoutResult(Result, LayoutResult);
+	if (!LayoutResult.bSucceeded)
+	{
+		AddSQLUISampleSmokeTestError(
+			Result,
+			LayoutResult.bJsonLayoutFixtureParseSucceeded
+				? TEXT("SQLUI sample pipeline smoke test failed: JSON layout fixture validation failed.")
+				: TEXT("SQLUI sample pipeline smoke test failed: JSON layout fixture parse failed."));
+		AddSQLUISampleLayoutValidationMessages(Result, LayoutResult.JsonLayoutFixtureValidation);
+		return Result;
+	}
 
 	USQLUIWidgetCatalog* WidgetCatalog = NewObject<USQLUIWidgetCatalog>(Outer);
 	if (!IsValid(WidgetCatalog))
@@ -175,7 +323,7 @@ FSQLUISampleSmokeTestResult USQLUISampleSmokeTestRunner::RunSmokeTest(
 	}
 
 	FSQLUIRuntimeWidgetPipelineRequest PipelineRequest;
-	PipelineRequest.Document = MakeSQLUISampleSmokeTestDocument(Request);
+	PipelineRequest.Document = LayoutResult.Document;
 	PipelineRequest.RuntimeContext = RuntimeContext;
 	PipelineRequest.WidgetCatalogOverride = WidgetCatalog;
 	PipelineRequest.WorldContextObject = WorldContextObject;
@@ -186,5 +334,14 @@ FSQLUISampleSmokeTestResult USQLUISampleSmokeTestRunner::RunSmokeTest(
 	PipelineRequest.bExecuteActions = Request.bExecuteActions;
 	PipelineRequest.bStopOnOptionalStepFailure = Request.bStopOnOptionalStepFailure;
 
-	return MakeSQLUISampleSmokeTestResult(Pipeline->RunPipeline(PipelineRequest));
+	return MakeSQLUISampleSmokeTestResult(Pipeline->RunPipeline(PipelineRequest), LayoutResult);
+}
+
+FSQLUISampleSmokeTestResult USQLUISampleSmokeTestRunner::RunJsonLayoutSmokeTest(
+	UObject* WorldContextObject,
+	const FSQLUISampleSmokeTestRequest& Request)
+{
+	FSQLUISampleSmokeTestRequest JsonRequest = Request;
+	JsonRequest.bUseJsonLayoutFixture = true;
+	return RunSmokeTest(WorldContextObject, JsonRequest);
 }

--- a/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISampleSmokeTestRunner.h
+++ b/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISampleSmokeTestRunner.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Layout/SQLUILayoutTypes.h"
 #include "Pipeline/SQLUIRuntimeWidgetPipeline.h"
 #include "UObject/Object.h"
 
@@ -33,6 +34,9 @@ struct SQLUISAMPLES_API FSQLUISampleSmokeTestRequest
 	bool bStopOnOptionalStepFailure = false;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bUseJsonLayoutFixture = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
 	FString SampleFilterText = TEXT("Smoke test");
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
@@ -49,6 +53,18 @@ struct SQLUISAMPLES_API FSQLUISampleSmokeTestResult
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
 	FString ErrorMessage;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bUsedJsonLayoutFixture = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bJsonLayoutFixtureParseSucceeded = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bJsonLayoutFixtureValidationSucceeded = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FSQLUILayoutValidationResult JsonLayoutFixtureValidation;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
 	TArray<FString> Errors;
@@ -77,6 +93,11 @@ class SQLUISAMPLES_API USQLUISampleSmokeTestRunner : public UObject
 public:
 	UFUNCTION(BlueprintCallable, Category = "SQLUI|Samples", meta = (WorldContext = "WorldContextObject"))
 	static FSQLUISampleSmokeTestResult RunSmokeTest(
+		UObject* WorldContextObject,
+		const FSQLUISampleSmokeTestRequest& Request);
+
+	UFUNCTION(BlueprintCallable, Category = "SQLUI|Samples", meta = (WorldContext = "WorldContextObject"))
+	static FSQLUISampleSmokeTestResult RunJsonLayoutSmokeTest(
 		UObject* WorldContextObject,
 		const FSQLUISampleSmokeTestRequest& Request);
 };

--- a/Scripts/RunSQLUISmokeTest.ps1
+++ b/Scripts/RunSQLUISmokeTest.ps1
@@ -6,6 +6,8 @@ param(
 
 	[string]$ProjectPath,
 
+	[switch]$UseJsonLayoutFixture,
+
 	[Alias('?')]
 	[switch]$Help
 )
@@ -33,11 +35,15 @@ Parameters:
       Optional path to JerryRigged.uproject. Defaults to ..\JerryRigged.uproject
       relative to this script.
 
+  -UseJsonLayoutFixture
+      Run the smoke test with the built-in SQLUISamples JSON layout fixture.
+
   -Help, -?
       Show this help.
 
 Examples:
   .\Scripts\RunSQLUISmokeTest.ps1 -EngineRoot "C:\Program Files\Epic Games\UE_5.7"
+  .\Scripts\RunSQLUISmokeTest.ps1 -EngineRoot "C:\Program Files\Epic Games\UE_5.7" -UseJsonLayoutFixture
   .\Scripts\RunSQLUISmokeTest.ps1 -UnrealEditorCmdPath "C:\UE\Engine\Binaries\Win64\UnrealEditor-Cmd.exe"
   .\Scripts\RunSQLUISmokeTest.ps1 -EngineRoot "C:\Program Files\Epic Games\UE_5.7" -ProjectPath ".\JerryRigged.uproject"
 '@
@@ -142,6 +148,11 @@ $CommandletArgs = @(
 	'-stdout',
 	'-FullStdOutLogOutput'
 )
+
+if ($UseJsonLayoutFixture)
+{
+	$CommandletArgs += '-UseJsonLayoutFixture'
+}
 
 $PrintableCommandParts = @($ResolvedUnrealEditorCmdPath) + $CommandletArgs
 $PrintableCommand = '& ' + (($PrintableCommandParts | ForEach-Object { Format-PowerShellCommandPart -Value $_ }) -join ' ')

--- a/docs/sqlui_smoke_test.md
+++ b/docs/sqlui_smoke_test.md
@@ -1,10 +1,12 @@
 # SQLUI Smoke Test
 
-The SQLUI sample smoke test commandlet runs the current sample runtime widget pipeline in a transient commandlet world. It creates the sample widget catalog, variable store, runtime context, and in-memory layout request, then reports whether the root widget and pipeline steps succeeded.
+The SQLUI sample smoke test commandlet runs the current sample runtime widget pipeline in a transient commandlet world. It creates the sample widget catalog, variable store, runtime context, and layout request, then reports whether the root widget and pipeline steps succeeded.
+
+By default, the smoke test uses the existing in-memory C++ layout document. It can also run the built-in SQLUISamples JSON layout fixture, which deserializes a tiny `SQLUI.FilterBox` layout through SQLUICore's layout JSON helpers before running the same runtime widget pipeline.
 
 This is a local developer workflow only. It is not CI yet, and it does not assume Unreal Engine is installed on GitHub Actions or any build agent.
 
-The smoke test does not edit maps, levels, Content, SQLite databases, or the viewport. It does not add database behavior.
+The smoke test does not edit maps, levels, Content, SQLite databases, or the viewport. It does not add database behavior or attach widgets to the viewport.
 
 ## Build JerryRiggedEditor
 
@@ -20,7 +22,7 @@ $ProjectPath = (Resolve-Path .\JerryRigged.uproject).Path
 
 If your engine is installed somewhere else, change `$EngineRoot`.
 
-## Run The Smoke Test
+## Run The Default Smoke Test
 
 From the repo root:
 
@@ -46,6 +48,16 @@ If you already know the exact editor commandlet executable path, pass `-UnrealEd
 powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\RunSQLUISmokeTest.ps1 -UnrealEditorCmdPath "C:\UE\Engine\Binaries\Win64\UnrealEditor-Cmd.exe"
 ```
 
+## Run The JSON Fixture Smoke Test
+
+The JSON fixture path keeps the same transient commandlet flow, but enables the built-in SQLUISamples JSON layout fixture with `-UseJsonLayoutFixture`:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\RunSQLUISmokeTest.ps1 -EngineRoot "C:\Program Files\Epic Games\UE_5.7" -UseJsonLayoutFixture
+```
+
+The commandlet also accepts `-JsonLayoutFixture` directly as an alias when invoking `UnrealEditor-Cmd.exe`.
+
 ## Expected Results
 
 The script prints the exact command it runs, then returns the same exit code as the commandlet.
@@ -58,6 +70,17 @@ SQLUI sample smoke test commandlet succeeded.
 SQLUI sample smoke test root widget valid: true
 SQLUI sample smoke test created widget count: 1
 SQLUI sample smoke test step '<StepName>': Succeeded
+```
+
+For the JSON fixture smoke test, also look for:
+
+```text
+SQLUI sample smoke test JSON fixture selected: true
+SQLUI sample smoke test JSON fixture parse succeeded.
+SQLUI sample smoke test JSON fixture validation succeeded.
+SQLUI sample smoke test commandlet succeeded.
+SQLUI sample smoke test root widget valid: true
+SQLUI sample smoke test created widget count: 1
 ```
 
 Some optional pipeline steps may log `Skipped` depending on the current sample request. Failures are logged with `SQLUI sample smoke test commandlet failed.` and the script returns a non-zero exit code.


### PR DESCRIPTION
Summary
- Added a JSON layout fixture path to the SQLUISamples smoke test flow
- Deserializes a tiny SQLUI.FilterBox layout through SQLUICore layout JSON helpers
- Runs the existing SQLUI runtime widget pipeline using the parsed layout document
- Added commandlet/script support for the JSON fixture smoke test
- Updated smoke test docs with JSON fixture usage

Validation
- Ran git diff --check
- Built JerryRiggedEditor Win64 Development successfully
- Ran the default SQLUI smoke test script successfully
- Ran the JSON fixture SQLUI smoke test script successfully

Notes
- Does not add SQLite/database behavior
- Does not edit maps or Content
- Does not attach widgets to viewport
- Does not touch JerryRigged host code
- Proves the JSON layout path before adding database-backed layout loading