### PR TITLE
Add SQLUICore in-memory layout repository

### DIFF
--- a/Plugins/SQLUI/Source/SQLUICore/Private/Layout/SQLUIInMemoryLayoutRepository.cpp
+++ b/Plugins/SQLUI/Source/SQLUICore/Private/Layout/SQLUIInMemoryLayoutRepository.cpp
@@ -1,0 +1,216 @@
+#include "Layout/SQLUIInMemoryLayoutRepository.h"
+
+#include "Layout/SQLUILayoutJson.h"
+
+namespace
+{
+const TCHAR* SQLUIInMemoryLayoutRepositoryEmptyLayoutIdMessage = TEXT("SQLUI in-memory layout repository requires a non-empty layout id.");
+const TCHAR* SQLUIInMemoryLayoutRepositoryInvalidDocumentMessage = TEXT("SQLUI in-memory layout repository could not save an invalid layout document.");
+
+void AddSQLUILayoutRepositoryValidationError(
+	FSQLUILayoutValidationResult& Validation,
+	const FString& ErrorMessage)
+{
+	Validation.bIsValid = false;
+	Validation.Errors.Add(ErrorMessage);
+}
+
+FSQLUILayoutLoadResult MakeSQLUIInMemoryLayoutLoadFailure(
+	const FString& LayoutId,
+	const FString& ErrorMessage)
+{
+	FSQLUILayoutLoadResult Result;
+	Result.bSucceeded = false;
+	Result.ErrorMessage = ErrorMessage;
+	Result.Document.Metadata.LayoutId = LayoutId;
+	return Result;
+}
+
+FSQLUILayoutSaveResult MakeSQLUIInMemoryLayoutSaveFailure(
+	const FString& LayoutId,
+	const FString& ErrorMessage,
+	const FSQLUILayoutValidationResult& Validation)
+{
+	FSQLUILayoutSaveResult Result;
+	Result.bSucceeded = false;
+	Result.ErrorMessage = ErrorMessage;
+	Result.SavedLayoutId = LayoutId;
+	Result.Validation = Validation;
+	return Result;
+}
+
+FSQLUILayoutRepositoryRemoveResult MakeSQLUIInMemoryLayoutRemoveFailure(
+	const FString& LayoutId,
+	const FString& ErrorMessage)
+{
+	FSQLUILayoutRepositoryRemoveResult Result;
+	Result.bSucceeded = false;
+	Result.ErrorMessage = ErrorMessage;
+	Result.RemovedLayoutId = LayoutId;
+	return Result;
+}
+}
+
+void USQLUIInMemoryLayoutRepository::LoadLayout(
+	const FString& LayoutId,
+	FSQLUILayoutLoadCompleteDelegate Callback)
+{
+	Callback.ExecuteIfBound(LoadLayoutById(LayoutId));
+}
+
+void USQLUIInMemoryLayoutRepository::SaveLayout(
+	const FSQLUILayoutDocument& Document,
+	FSQLUILayoutSaveCompleteDelegate Callback)
+{
+	const FString& LayoutId = Document.Metadata.LayoutId;
+	FSQLUILayoutValidationResult Validation = FSQLUILayoutJson::ValidateDocument(Document);
+
+	if (LayoutId.IsEmpty())
+	{
+		AddSQLUILayoutRepositoryValidationError(
+			Validation,
+			SQLUIInMemoryLayoutRepositoryEmptyLayoutIdMessage);
+		Callback.ExecuteIfBound(MakeSQLUIInMemoryLayoutSaveFailure(
+			LayoutId,
+			SQLUIInMemoryLayoutRepositoryEmptyLayoutIdMessage,
+			Validation));
+		return;
+	}
+
+	if (!Validation.bIsValid)
+	{
+		Callback.ExecuteIfBound(MakeSQLUIInMemoryLayoutSaveFailure(
+			LayoutId,
+			SQLUIInMemoryLayoutRepositoryInvalidDocumentMessage,
+			Validation));
+		return;
+	}
+
+	LayoutsById.Add(LayoutId, Document);
+
+	FSQLUILayoutSaveResult Result;
+	Result.bSucceeded = true;
+	Result.SavedLayoutId = LayoutId;
+	Result.Validation = Validation;
+	Callback.ExecuteIfBound(Result);
+}
+
+FSQLUILayoutLoadResult USQLUIInMemoryLayoutRepository::LoadLayoutById(const FString& LayoutId) const
+{
+	if (LayoutId.IsEmpty())
+	{
+		return MakeSQLUIInMemoryLayoutLoadFailure(
+			LayoutId,
+			SQLUIInMemoryLayoutRepositoryEmptyLayoutIdMessage);
+	}
+
+	const FSQLUILayoutDocument* StoredDocument = LayoutsById.Find(LayoutId);
+	if (!StoredDocument)
+	{
+		return MakeSQLUIInMemoryLayoutLoadFailure(
+			LayoutId,
+			FString::Printf(TEXT("SQLUI in-memory layout repository could not find layout id '%s'."), *LayoutId));
+	}
+
+	FSQLUILayoutLoadResult Result;
+	Result.bSucceeded = true;
+	Result.Document = *StoredDocument;
+	Result.Validation = FSQLUILayoutJson::ValidateDocument(Result.Document);
+	return Result;
+}
+
+FSQLUILayoutLoadResult USQLUIInMemoryLayoutRepository::LoadLayoutByDisplayName(const FString& DisplayName) const
+{
+	if (DisplayName.IsEmpty())
+	{
+		return MakeSQLUIInMemoryLayoutLoadFailure(
+			FString(),
+			TEXT("SQLUI in-memory layout repository requires a non-empty display name."));
+	}
+
+	const FSQLUILayoutDocument* MatchingDocument = nullptr;
+	for (const TPair<FString, FSQLUILayoutDocument>& LayoutPair : LayoutsById)
+	{
+		if (LayoutPair.Value.Metadata.DisplayName != DisplayName)
+		{
+			continue;
+		}
+
+		if (!MatchingDocument ||
+			LayoutPair.Value.Metadata.LayoutId.Compare(MatchingDocument->Metadata.LayoutId, ESearchCase::IgnoreCase) < 0)
+		{
+			MatchingDocument = &LayoutPair.Value;
+		}
+	}
+
+	if (MatchingDocument)
+	{
+		FSQLUILayoutLoadResult Result;
+		Result.bSucceeded = true;
+		Result.Document = *MatchingDocument;
+		Result.Validation = FSQLUILayoutJson::ValidateDocument(Result.Document);
+		return Result;
+	}
+
+	return MakeSQLUIInMemoryLayoutLoadFailure(
+		FString(),
+		FString::Printf(TEXT("SQLUI in-memory layout repository could not find display name '%s'."), *DisplayName));
+}
+
+FSQLUILayoutRepositoryRemoveResult USQLUIInMemoryLayoutRepository::RemoveLayout(const FString& LayoutId)
+{
+	if (LayoutId.IsEmpty())
+	{
+		return MakeSQLUIInMemoryLayoutRemoveFailure(
+			LayoutId,
+			SQLUIInMemoryLayoutRepositoryEmptyLayoutIdMessage);
+	}
+
+	FSQLUILayoutRepositoryRemoveResult Result;
+	Result.RemovedLayoutId = LayoutId;
+	Result.bRemoved = LayoutsById.Remove(LayoutId) > 0;
+	Result.bSucceeded = true;
+
+	if (!Result.bRemoved)
+	{
+		Result.ErrorMessage = FString::Printf(
+			TEXT("SQLUI in-memory layout repository did not contain layout id '%s'."),
+			*LayoutId);
+	}
+
+	return Result;
+}
+
+FSQLUILayoutRepositoryListResult USQLUIInMemoryLayoutRepository::ListLayouts() const
+{
+	FSQLUILayoutRepositoryListResult Result;
+	Result.bSucceeded = true;
+	Result.Layouts.Reserve(LayoutsById.Num());
+
+	for (const TPair<FString, FSQLUILayoutDocument>& LayoutPair : LayoutsById)
+	{
+		Result.Layouts.Add(LayoutPair.Value.Metadata);
+	}
+
+	Result.Layouts.Sort([](const FSQLUILayoutMetadata& Left, const FSQLUILayoutMetadata& Right)
+	{
+		const int32 DisplayNameCompare = Left.DisplayName.Compare(Right.DisplayName, ESearchCase::IgnoreCase);
+		if (DisplayNameCompare != 0)
+		{
+			return DisplayNameCompare < 0;
+		}
+
+		return Left.LayoutId.Compare(Right.LayoutId, ESearchCase::IgnoreCase) < 0;
+	});
+
+	return Result;
+}
+
+FSQLUILayoutRepositoryClearResult USQLUIInMemoryLayoutRepository::ClearLayouts()
+{
+	FSQLUILayoutRepositoryClearResult Result;
+	Result.bSucceeded = true;
+	Result.RemovedCount = LayoutsById.Num();
+	LayoutsById.Empty();
+	return Result;
+}

--- a/Plugins/SQLUI/Source/SQLUICore/Public/Layout/SQLUIInMemoryLayoutRepository.h
+++ b/Plugins/SQLUI/Source/SQLUICore/Public/Layout/SQLUIInMemoryLayoutRepository.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Layout/SQLUILayoutRepository.h"
+
+#include "SQLUIInMemoryLayoutRepository.generated.h"
+
+USTRUCT(BlueprintType)
+struct SQLUICORE_API FSQLUILayoutRepositoryListResult
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Repository")
+	bool bSucceeded = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Repository")
+	FString ErrorMessage;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Repository")
+	TArray<FSQLUILayoutMetadata> Layouts;
+};
+
+USTRUCT(BlueprintType)
+struct SQLUICORE_API FSQLUILayoutRepositoryRemoveResult
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Repository")
+	bool bSucceeded = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Repository")
+	FString ErrorMessage;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Repository")
+	FString RemovedLayoutId;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Repository")
+	bool bRemoved = false;
+};
+
+USTRUCT(BlueprintType)
+struct SQLUICORE_API FSQLUILayoutRepositoryClearResult
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Repository")
+	bool bSucceeded = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Repository")
+	FString ErrorMessage;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Layout Repository")
+	int32 RemovedCount = 0;
+};
+
+UCLASS(BlueprintType)
+class SQLUICORE_API USQLUIInMemoryLayoutRepository : public USQLUILayoutRepository
+{
+	GENERATED_BODY()
+
+public:
+	virtual void LoadLayout(const FString& LayoutId, FSQLUILayoutLoadCompleteDelegate Callback) override;
+	virtual void SaveLayout(const FSQLUILayoutDocument& Document, FSQLUILayoutSaveCompleteDelegate Callback) override;
+
+	UFUNCTION(BlueprintCallable, Category = "SQLUI|Layout Repository")
+	FSQLUILayoutLoadResult LoadLayoutById(const FString& LayoutId) const;
+
+	UFUNCTION(BlueprintCallable, Category = "SQLUI|Layout Repository")
+	FSQLUILayoutLoadResult LoadLayoutByDisplayName(const FString& DisplayName) const;
+
+	UFUNCTION(BlueprintCallable, Category = "SQLUI|Layout Repository")
+	FSQLUILayoutRepositoryRemoveResult RemoveLayout(const FString& LayoutId);
+
+	UFUNCTION(BlueprintCallable, Category = "SQLUI|Layout Repository")
+	FSQLUILayoutRepositoryListResult ListLayouts() const;
+
+	UFUNCTION(BlueprintCallable, Category = "SQLUI|Layout Repository")
+	FSQLUILayoutRepositoryClearResult ClearLayouts();
+
+private:
+	UPROPERTY(Transient)
+	TMap<FString, FSQLUILayoutDocument> LayoutsById;
+};


### PR DESCRIPTION
Summary
- Added an in-memory SQLUI layout repository implementation
- Supports saving, loading, listing, removing, and clearing layout documents in memory
- Validates layout documents before saving
- Keeps repository storage transient and non-persistent
- Preserves the repository boundary before adding SQLite-backed persistence

Validation
- Ran git diff --check
- Built JerryRiggedEditor Win64 Development successfully
- Optionally ran the JSON layout smoke test successfully

Notes
- Does not add SQLite/database behavior
- Does not add file I/O
- Does not edit maps or Content
- Does not touch SQLUIWidgets or SQLUISamples
- Prepares the repository layer for a future SQLite-backed implementation