### PR TITLE
Add SQLUISamples in-memory repository smoke path

### DIFF
--- a/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISamplePipelineSmokeTestActor.cpp
+++ b/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISamplePipelineSmokeTestActor.cpp
@@ -84,9 +84,85 @@ void LogSQLUISamplePipelineSmokeTestJsonFixtureResult(
 	LogSQLUISamplePipelineSmokeTestJsonFixtureMessages(Result.JsonLayoutFixtureValidation);
 }
 
+void LogSQLUISamplePipelineSmokeTestRepositoryValidationMessages(
+	const TCHAR* OperationName,
+	const FSQLUILayoutValidationResult& Validation)
+{
+	for (const FString& Error : Validation.Errors)
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample pipeline smoke test in-memory layout repository %s validation error: %s"),
+			OperationName,
+			*Error);
+	}
+
+	for (const FString& Warning : Validation.Warnings)
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Warning,
+			TEXT("SQLUI sample pipeline smoke test in-memory layout repository %s validation warning: %s"),
+			OperationName,
+			*Warning);
+	}
+}
+
+void LogSQLUISamplePipelineSmokeTestRepositoryResult(
+	const FSQLUISampleSmokeTestResult& Result)
+{
+	if (!Result.bUsedInMemoryLayoutRepository)
+	{
+		return;
+	}
+
+	UE_LOG(LogSQLUISamples, Log, TEXT("SQLUI sample pipeline smoke test in-memory layout repository selected."));
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample pipeline smoke test in-memory layout repository save %s. LayoutId='%s'"),
+		Result.bRepositorySaveSucceeded ? TEXT("succeeded") : TEXT("failed"),
+		*Result.SavedLayoutId);
+
+	if (!Result.RepositorySaveErrorMessage.IsEmpty())
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample pipeline smoke test in-memory layout repository save error: %s"),
+			*Result.RepositorySaveErrorMessage);
+	}
+
+	LogSQLUISamplePipelineSmokeTestRepositoryValidationMessages(
+		TEXT("save"),
+		Result.RepositorySaveValidation);
+
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample pipeline smoke test in-memory layout repository load %s. LayoutId='%s'"),
+		Result.bRepositoryLoadSucceeded ? TEXT("succeeded") : TEXT("failed"),
+		*Result.LoadedLayoutId);
+
+	if (!Result.RepositoryLoadErrorMessage.IsEmpty())
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample pipeline smoke test in-memory layout repository load error: %s"),
+			*Result.RepositoryLoadErrorMessage);
+	}
+
+	LogSQLUISamplePipelineSmokeTestRepositoryValidationMessages(
+		TEXT("load"),
+		Result.RepositoryLoadValidation);
+}
+
 void LogSQLUISamplePipelineSmokeTestResult(const FSQLUISampleSmokeTestResult& Result)
 {
 	LogSQLUISamplePipelineSmokeTestJsonFixtureResult(Result);
+	LogSQLUISamplePipelineSmokeTestRepositoryResult(Result);
 
 	UE_LOG(
 		LogSQLUISamples,

--- a/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleSmokeTestCommandlet.cpp
+++ b/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleSmokeTestCommandlet.cpp
@@ -96,6 +96,81 @@ void LogSQLUISampleSmokeTestJsonFixtureResult(
 	LogSQLUISampleSmokeTestJsonFixtureMessages(Result.JsonLayoutFixtureValidation);
 }
 
+void LogSQLUISampleSmokeTestRepositoryValidationMessages(
+	const TCHAR* OperationName,
+	const FSQLUILayoutValidationResult& Validation)
+{
+	for (const FString& Error : Validation.Errors)
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample smoke test in-memory layout repository %s validation error: %s"),
+			OperationName,
+			*Error);
+	}
+
+	for (const FString& Warning : Validation.Warnings)
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Warning,
+			TEXT("SQLUI sample smoke test in-memory layout repository %s validation warning: %s"),
+			OperationName,
+			*Warning);
+	}
+}
+
+void LogSQLUISampleSmokeTestRepositoryResult(
+	const FSQLUISampleSmokeTestResult& Result)
+{
+	if (!Result.bUsedInMemoryLayoutRepository)
+	{
+		return;
+	}
+
+	UE_LOG(LogSQLUISamples, Log, TEXT("SQLUI sample smoke test in-memory layout repository selected."));
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample smoke test in-memory layout repository save %s. LayoutId='%s'"),
+		Result.bRepositorySaveSucceeded ? TEXT("succeeded") : TEXT("failed"),
+		*Result.SavedLayoutId);
+
+	if (!Result.RepositorySaveErrorMessage.IsEmpty())
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample smoke test in-memory layout repository save error: %s"),
+			*Result.RepositorySaveErrorMessage);
+	}
+
+	LogSQLUISampleSmokeTestRepositoryValidationMessages(
+		TEXT("save"),
+		Result.RepositorySaveValidation);
+
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample smoke test in-memory layout repository load %s. LayoutId='%s'"),
+		Result.bRepositoryLoadSucceeded ? TEXT("succeeded") : TEXT("failed"),
+		*Result.LoadedLayoutId);
+
+	if (!Result.RepositoryLoadErrorMessage.IsEmpty())
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample smoke test in-memory layout repository load error: %s"),
+			*Result.RepositoryLoadErrorMessage);
+	}
+
+	LogSQLUISampleSmokeTestRepositoryValidationMessages(
+		TEXT("load"),
+		Result.RepositoryLoadValidation);
+}
+
 void LogSQLUISampleSmokeTestStepErrors(
 	const TCHAR* StepName,
 	const TArray<FString>& Messages)
@@ -129,6 +204,7 @@ void LogSQLUISampleSmokeTestStepWarnings(
 void LogSQLUISampleSmokeTestResult(const FSQLUISampleSmokeTestResult& Result)
 {
 	LogSQLUISampleSmokeTestJsonFixtureResult(Result);
+	LogSQLUISampleSmokeTestRepositoryResult(Result);
 
 	UE_LOG(
 		LogSQLUISamples,
@@ -192,15 +268,25 @@ USQLUISampleSmokeTestCommandlet::USQLUISampleSmokeTestCommandlet()
 int32 USQLUISampleSmokeTestCommandlet::Main(const FString& Params)
 {
 	UE_LOG(LogSQLUISamples, Log, TEXT("SQLUI sample smoke test commandlet started."));
+	const bool bUseInMemoryLayoutRepository =
+		FParse::Param(*Params, TEXT("UseInMemoryLayoutRepository"))
+		|| FParse::Param(*Params, TEXT("InMemoryLayoutRepository"));
 	const bool bUseJsonLayoutFixture =
 		FParse::Param(*Params, TEXT("UseJsonLayoutFixture"))
-		|| FParse::Param(*Params, TEXT("JsonLayoutFixture"));
+		|| FParse::Param(*Params, TEXT("JsonLayoutFixture"))
+		|| bUseInMemoryLayoutRepository;
 
 	UE_LOG(
 		LogSQLUISamples,
 		Log,
 		TEXT("SQLUI sample smoke test JSON fixture selected: %s"),
 		bUseJsonLayoutFixture ? TEXT("true") : TEXT("false"));
+
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample smoke test in-memory layout repository selected: %s"),
+		bUseInMemoryLayoutRepository ? TEXT("true") : TEXT("false"));
 
 	UWorld* CommandletWorld = CreateSQLUISampleSmokeTestCommandletWorld();
 	if (!CommandletWorld)
@@ -216,6 +302,7 @@ int32 USQLUISampleSmokeTestCommandlet::Main(const FString& Params)
 	{
 		FSQLUISampleSmokeTestRequest Request;
 		Request.bUseJsonLayoutFixture = bUseJsonLayoutFixture;
+		Request.bUseInMemoryLayoutRepository = bUseInMemoryLayoutRepository;
 		Result = USQLUISampleSmokeTestRunner::RunSmokeTest(CommandletWorld, Request);
 	}
 

--- a/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleSmokeTestRunner.cpp
+++ b/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleSmokeTestRunner.cpp
@@ -1,5 +1,6 @@
 #include "SQLUISampleSmokeTestRunner.h"
 
+#include "Layout/SQLUIInMemoryLayoutRepository.h"
 #include "Layout/SQLUILayoutJson.h"
 #include "Layout/SQLUILayoutTypes.h"
 #include "Runtime/SQLUIRuntimeContext.h"
@@ -73,6 +74,15 @@ struct FSQLUISampleSmokeTestLayoutResult
 	bool bJsonLayoutFixtureParseSucceeded = false;
 	bool bJsonLayoutFixtureValidationSucceeded = false;
 	FSQLUILayoutValidationResult JsonLayoutFixtureValidation;
+	bool bUsedInMemoryLayoutRepository = false;
+	bool bRepositorySaveSucceeded = false;
+	bool bRepositoryLoadSucceeded = false;
+	FString SavedLayoutId;
+	FString LoadedLayoutId;
+	FString RepositorySaveErrorMessage;
+	FString RepositoryLoadErrorMessage;
+	FSQLUILayoutValidationResult RepositorySaveValidation;
+	FSQLUILayoutValidationResult RepositoryLoadValidation;
 	FSQLUILayoutDocument Document;
 };
 
@@ -156,13 +166,84 @@ bool DidSQLUISampleLayoutJsonParseFail(const FSQLUILayoutValidationResult& Valid
 	return false;
 }
 
+FSQLUILayoutSaveResult SaveSQLUISampleLayoutToRepository(
+	USQLUIInMemoryLayoutRepository* Repository,
+	const FSQLUILayoutDocument& Document)
+{
+	FSQLUILayoutSaveResult SaveResult;
+	SaveResult.SavedLayoutId = Document.Metadata.LayoutId;
+
+	if (!IsValid(Repository))
+	{
+		SaveResult.ErrorMessage =
+			TEXT("SQLUI sample smoke test failed: could not create in-memory layout repository.");
+		return SaveResult;
+	}
+
+	bool bSaveCompleted = false;
+	Repository->SaveLayout(
+		Document,
+		FSQLUILayoutSaveCompleteDelegate::CreateLambda(
+			[&SaveResult, &bSaveCompleted](const FSQLUILayoutSaveResult& InSaveResult)
+			{
+				SaveResult = InSaveResult;
+				bSaveCompleted = true;
+			}));
+
+	if (!bSaveCompleted)
+	{
+		SaveResult.bSucceeded = false;
+		SaveResult.ErrorMessage =
+			TEXT("SQLUI sample smoke test failed: in-memory layout repository save did not complete.");
+	}
+
+	return SaveResult;
+}
+
+FSQLUILayoutLoadResult LoadSQLUISampleLayoutFromRepository(
+	USQLUIInMemoryLayoutRepository* Repository,
+	const FString& LayoutId)
+{
+	FSQLUILayoutLoadResult LoadResult;
+	LoadResult.Document.Metadata.LayoutId = LayoutId;
+
+	if (!IsValid(Repository))
+	{
+		LoadResult.ErrorMessage =
+			TEXT("SQLUI sample smoke test failed: could not create in-memory layout repository.");
+		return LoadResult;
+	}
+
+	bool bLoadCompleted = false;
+	Repository->LoadLayout(
+		LayoutId,
+		FSQLUILayoutLoadCompleteDelegate::CreateLambda(
+			[&LoadResult, &bLoadCompleted](const FSQLUILayoutLoadResult& InLoadResult)
+			{
+				LoadResult = InLoadResult;
+				bLoadCompleted = true;
+			}));
+
+	if (!bLoadCompleted)
+	{
+		LoadResult.bSucceeded = false;
+		LoadResult.ErrorMessage =
+			TEXT("SQLUI sample smoke test failed: in-memory layout repository load did not complete.");
+	}
+
+	return LoadResult;
+}
+
 FSQLUISampleSmokeTestLayoutResult ResolveSQLUISampleSmokeTestLayoutDocument(
+	UObject* Outer,
 	const FSQLUISampleSmokeTestRequest& Request)
 {
 	FSQLUISampleSmokeTestLayoutResult Result;
-	Result.bUsedJsonLayoutFixture = Request.bUseJsonLayoutFixture;
+	Result.bUsedInMemoryLayoutRepository = Request.bUseInMemoryLayoutRepository;
+	Result.bUsedJsonLayoutFixture =
+		Request.bUseJsonLayoutFixture || Request.bUseInMemoryLayoutRepository;
 
-	if (!Request.bUseJsonLayoutFixture)
+	if (!Result.bUsedJsonLayoutFixture)
 	{
 		Result.Document = MakeSQLUISampleSmokeTestDocument(Request);
 		return Result;
@@ -178,6 +259,49 @@ FSQLUISampleSmokeTestLayoutResult ResolveSQLUISampleSmokeTestLayoutDocument(
 	Result.bJsonLayoutFixtureValidationSucceeded =
 		Result.bJsonLayoutFixtureParseSucceeded && Result.JsonLayoutFixtureValidation.bIsValid;
 	Result.bSucceeded = bParsedAndValidated;
+	if (!Result.bSucceeded || !Request.bUseInMemoryLayoutRepository)
+	{
+		return Result;
+	}
+
+	USQLUIInMemoryLayoutRepository* LayoutRepository =
+		NewObject<USQLUIInMemoryLayoutRepository>(Outer);
+	const FSQLUILayoutSaveResult SaveResult =
+		SaveSQLUISampleLayoutToRepository(LayoutRepository, Result.Document);
+
+	Result.bRepositorySaveSucceeded = SaveResult.bSucceeded;
+	Result.SavedLayoutId = SaveResult.SavedLayoutId;
+	Result.RepositorySaveErrorMessage = SaveResult.ErrorMessage;
+	Result.RepositorySaveValidation = SaveResult.Validation;
+
+	if (!SaveResult.bSucceeded)
+	{
+		Result.bSucceeded = false;
+		return Result;
+	}
+
+	const FString LayoutId = Result.Document.Metadata.LayoutId;
+	const FSQLUILayoutLoadResult LoadResult =
+		LoadSQLUISampleLayoutFromRepository(LayoutRepository, LayoutId);
+
+	Result.bRepositoryLoadSucceeded =
+		LoadResult.bSucceeded && LoadResult.Validation.bIsValid;
+	Result.LoadedLayoutId = LoadResult.Document.Metadata.LayoutId;
+	Result.RepositoryLoadErrorMessage = LoadResult.ErrorMessage;
+	Result.RepositoryLoadValidation = LoadResult.Validation;
+
+	if (!Result.bRepositoryLoadSucceeded)
+	{
+		Result.bSucceeded = false;
+		if (Result.RepositoryLoadErrorMessage.IsEmpty())
+		{
+			Result.RepositoryLoadErrorMessage =
+				TEXT("SQLUI sample smoke test failed: in-memory layout repository loaded an invalid layout document.");
+		}
+		return Result;
+	}
+
+	Result.Document = LoadResult.Document;
 	return Result;
 }
 
@@ -189,6 +313,15 @@ void ApplySQLUISampleLayoutResult(
 	Result.bJsonLayoutFixtureParseSucceeded = LayoutResult.bJsonLayoutFixtureParseSucceeded;
 	Result.bJsonLayoutFixtureValidationSucceeded = LayoutResult.bJsonLayoutFixtureValidationSucceeded;
 	Result.JsonLayoutFixtureValidation = LayoutResult.JsonLayoutFixtureValidation;
+	Result.bUsedInMemoryLayoutRepository = LayoutResult.bUsedInMemoryLayoutRepository;
+	Result.bRepositorySaveSucceeded = LayoutResult.bRepositorySaveSucceeded;
+	Result.bRepositoryLoadSucceeded = LayoutResult.bRepositoryLoadSucceeded;
+	Result.SavedLayoutId = LayoutResult.SavedLayoutId;
+	Result.LoadedLayoutId = LayoutResult.LoadedLayoutId;
+	Result.RepositorySaveErrorMessage = LayoutResult.RepositorySaveErrorMessage;
+	Result.RepositoryLoadErrorMessage = LayoutResult.RepositoryLoadErrorMessage;
+	Result.RepositorySaveValidation = LayoutResult.RepositorySaveValidation;
+	Result.RepositoryLoadValidation = LayoutResult.RepositoryLoadValidation;
 }
 
 void AddSQLUISampleLayoutValidationMessages(
@@ -204,6 +337,32 @@ void AddSQLUISampleLayoutValidationMessages(
 	{
 		Result.Warnings.Add(Warning);
 	}
+}
+
+FString MakeSQLUISampleLayoutFailureMessage(
+	const FSQLUISampleSmokeTestLayoutResult& LayoutResult)
+{
+	if (LayoutResult.bUsedJsonLayoutFixture && !LayoutResult.bJsonLayoutFixtureParseSucceeded)
+	{
+		return TEXT("SQLUI sample pipeline smoke test failed: JSON layout fixture parse failed.");
+	}
+
+	if (LayoutResult.bUsedJsonLayoutFixture && !LayoutResult.bJsonLayoutFixtureValidationSucceeded)
+	{
+		return TEXT("SQLUI sample pipeline smoke test failed: JSON layout fixture validation failed.");
+	}
+
+	if (LayoutResult.bUsedInMemoryLayoutRepository && !LayoutResult.bRepositorySaveSucceeded)
+	{
+		return TEXT("SQLUI sample pipeline smoke test failed: in-memory layout repository save failed.");
+	}
+
+	if (LayoutResult.bUsedInMemoryLayoutRepository && !LayoutResult.bRepositoryLoadSucceeded)
+	{
+		return TEXT("SQLUI sample pipeline smoke test failed: in-memory layout repository load failed.");
+	}
+
+	return TEXT("SQLUI sample pipeline smoke test failed: layout document could not be resolved.");
 }
 
 void SeedSQLUISampleSmokeTestVariables(
@@ -250,16 +409,16 @@ FSQLUISampleSmokeTestResult USQLUISampleSmokeTestRunner::RunSmokeTest(
 	UObject* Outer = ResolveSQLUISampleSmokeTestOuter(WorldContextObject, Request);
 
 	const FSQLUISampleSmokeTestLayoutResult LayoutResult =
-		ResolveSQLUISampleSmokeTestLayoutDocument(Request);
+		ResolveSQLUISampleSmokeTestLayoutDocument(Outer, Request);
 	ApplySQLUISampleLayoutResult(Result, LayoutResult);
 	if (!LayoutResult.bSucceeded)
 	{
-		AddSQLUISampleSmokeTestError(
-			Result,
-			LayoutResult.bJsonLayoutFixtureParseSucceeded
-				? TEXT("SQLUI sample pipeline smoke test failed: JSON layout fixture validation failed.")
-				: TEXT("SQLUI sample pipeline smoke test failed: JSON layout fixture parse failed."));
+		AddSQLUISampleSmokeTestError(Result, MakeSQLUISampleLayoutFailureMessage(LayoutResult));
 		AddSQLUISampleLayoutValidationMessages(Result, LayoutResult.JsonLayoutFixtureValidation);
+		AddSQLUISampleLayoutValidationMessages(Result, LayoutResult.RepositorySaveValidation);
+		AddSQLUISampleLayoutValidationMessages(Result, LayoutResult.RepositoryLoadValidation);
+		AddSQLUISampleSmokeTestError(Result, LayoutResult.RepositorySaveErrorMessage);
+		AddSQLUISampleSmokeTestError(Result, LayoutResult.RepositoryLoadErrorMessage);
 		return Result;
 	}
 

--- a/Scripts/RunSQLUISmokeTest.ps1
+++ b/Scripts/RunSQLUISmokeTest.ps1
@@ -8,6 +8,8 @@ param(
 
 	[switch]$UseJsonLayoutFixture,
 
+	[switch]$UseInMemoryLayoutRepository,
+
 	[Alias('?')]
 	[switch]$Help
 )
@@ -38,12 +40,17 @@ Parameters:
   -UseJsonLayoutFixture
       Run the smoke test with the built-in SQLUISamples JSON layout fixture.
 
+  -UseInMemoryLayoutRepository
+      Run the JSON fixture through the SQLUISamples in-memory layout repository
+      before running the runtime widget pipeline.
+
   -Help, -?
       Show this help.
 
 Examples:
   .\Scripts\RunSQLUISmokeTest.ps1 -EngineRoot "C:\Program Files\Epic Games\UE_5.7"
   .\Scripts\RunSQLUISmokeTest.ps1 -EngineRoot "C:\Program Files\Epic Games\UE_5.7" -UseJsonLayoutFixture
+  .\Scripts\RunSQLUISmokeTest.ps1 -EngineRoot "C:\Program Files\Epic Games\UE_5.7" -UseInMemoryLayoutRepository
   .\Scripts\RunSQLUISmokeTest.ps1 -UnrealEditorCmdPath "C:\UE\Engine\Binaries\Win64\UnrealEditor-Cmd.exe"
   .\Scripts\RunSQLUISmokeTest.ps1 -EngineRoot "C:\Program Files\Epic Games\UE_5.7" -ProjectPath ".\JerryRigged.uproject"
 '@
@@ -146,12 +153,18 @@ $CommandletArgs = @(
 	'-nosplash',
 	'-nullrhi',
 	'-stdout',
-	'-FullStdOutLogOutput'
+	'-FullStdOutLogOutput',
+	'-DDC-AllowNoActiveStores'
 )
 
 if ($UseJsonLayoutFixture)
 {
 	$CommandletArgs += '-UseJsonLayoutFixture'
+}
+
+if ($UseInMemoryLayoutRepository)
+{
+	$CommandletArgs += '-UseInMemoryLayoutRepository'
 }
 
 $PrintableCommandParts = @($ResolvedUnrealEditorCmdPath) + $CommandletArgs

--- a/docs/sqlui_smoke_test.md
+++ b/docs/sqlui_smoke_test.md
@@ -4,9 +4,11 @@ The SQLUI sample smoke test commandlet runs the current sample runtime widget pi
 
 By default, the smoke test uses the existing in-memory C++ layout document. It can also run the built-in SQLUISamples JSON layout fixture, which deserializes a tiny `SQLUI.FilterBox` layout through SQLUICore's layout JSON helpers before running the same runtime widget pipeline.
 
+The in-memory repository smoke path reuses that same JSON fixture, saves the deserialized layout into `USQLUIInMemoryLayoutRepository`, loads it back by layout id, and then runs the runtime widget pipeline with the loaded document.
+
 This is a local developer workflow only. It is not CI yet, and it does not assume Unreal Engine is installed on GitHub Actions or any build agent.
 
-The smoke test does not edit maps, levels, Content, SQLite databases, or the viewport. It does not add database behavior or attach widgets to the viewport.
+The smoke test does not edit maps, levels, Content, SQLite databases, files, or the viewport. It does not add database behavior, use SQLite, perform file I/O, or attach widgets to the viewport.
 
 ## Build JerryRiggedEditor
 
@@ -58,9 +60,21 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\RunSQLUISmokeTest.
 
 The commandlet also accepts `-JsonLayoutFixture` directly as an alias when invoking `UnrealEditor-Cmd.exe`.
 
+## Run The In-Memory Repository Smoke Test
+
+The in-memory repository path keeps the same transient commandlet flow, deserializes the built-in SQLUISamples JSON layout fixture, saves it into `USQLUIInMemoryLayoutRepository`, loads it back by `LayoutId`, and runs the same runtime widget pipeline with the loaded layout document:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\RunSQLUISmokeTest.ps1 -EngineRoot "C:\Program Files\Epic Games\UE_5.7" -UseInMemoryLayoutRepository
+```
+
+The commandlet also accepts `-InMemoryLayoutRepository` directly as an alias when invoking `UnrealEditor-Cmd.exe`.
+
+This path is still sample scaffolding only. It does not use SQLite, disk persistence, file I/O, maps, Content, or viewport attachment.
+
 ## Expected Results
 
-The script prints the exact command it runs, then returns the same exit code as the commandlet.
+The script prints the exact command it runs, then returns the same exit code as the commandlet. It passes `-DDC-AllowNoActiveStores` so this transient smoke-test commandlet does not require a writable local Derived Data Cache.
 
 On success, the commandlet exits with code `0`. Look for log lines like:
 
@@ -78,6 +92,20 @@ For the JSON fixture smoke test, also look for:
 SQLUI sample smoke test JSON fixture selected: true
 SQLUI sample smoke test JSON fixture parse succeeded.
 SQLUI sample smoke test JSON fixture validation succeeded.
+SQLUI sample smoke test commandlet succeeded.
+SQLUI sample smoke test root widget valid: true
+SQLUI sample smoke test created widget count: 1
+```
+
+For the in-memory repository smoke test, also look for:
+
+```text
+SQLUI sample smoke test JSON fixture selected: true
+SQLUI sample smoke test JSON fixture parse succeeded.
+SQLUI sample smoke test JSON fixture validation succeeded.
+SQLUI sample smoke test in-memory layout repository selected.
+SQLUI sample smoke test in-memory layout repository save succeeded.
+SQLUI sample smoke test in-memory layout repository load succeeded.
 SQLUI sample smoke test commandlet succeeded.
 SQLUI sample smoke test root widget valid: true
 SQLUI sample smoke test created widget count: 1


### PR DESCRIPTION
Summary
- Added an in-memory repository smoke-test path to SQLUISamples
- Deserializes the JSON layout fixture and saves it into USQLUIInMemoryLayoutRepository
- Loads the layout back from the repository and runs the SQLUI runtime widget pipeline
- Added commandlet/script support for the in-memory repository smoke path
- Updated smoke test docs with repository smoke-test usage

Validation
- Ran git diff --check
- Built JerryRiggedEditor Win64 Development successfully
- Ran the default SQLUI smoke test script successfully
- Ran the JSON fixture SQLUI smoke test script successfully
- Ran the in-memory repository SQLUI smoke test script successfully

Notes
- Does not add SQLite/database behavior
- Does not add file I/O or disk persistence
- Does not edit maps or Content
- Does not attach widgets to viewport
- Does not touch JerryRigged host code
- Proves the repository boundary before adding SQLite-backed layout loading