### PR TITLE
Add SQLUISamples JSON file repository smoke path

### DIFF
--- a/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISamplePipelineSmokeTestActor.cpp
+++ b/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISamplePipelineSmokeTestActor.cpp
@@ -159,10 +159,53 @@ void LogSQLUISamplePipelineSmokeTestRepositoryResult(
 		Result.RepositoryLoadValidation);
 }
 
+void LogSQLUISamplePipelineSmokeTestJsonFileRepositoryResult(
+	const FSQLUISampleSmokeTestResult& Result)
+{
+	if (!Result.bUsedJsonFileLayoutRepository)
+	{
+		return;
+	}
+
+	UE_LOG(LogSQLUISamples, Log, TEXT("SQLUI sample pipeline smoke test JSON file layout repository selected."));
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample pipeline smoke test JSON file layout repository save %s. LayoutId='%s'"),
+		Result.bJsonFileRepositorySaveSucceeded ? TEXT("succeeded") : TEXT("failed"),
+		*Result.JsonFileRepositorySavedLayoutId);
+
+	if (!Result.JsonFileRepositorySaveErrorMessage.IsEmpty())
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample pipeline smoke test JSON file layout repository save error: %s"),
+			*Result.JsonFileRepositorySaveErrorMessage);
+	}
+
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample pipeline smoke test JSON file layout repository load %s. LayoutId='%s'"),
+		Result.bJsonFileRepositoryLoadSucceeded ? TEXT("succeeded") : TEXT("failed"),
+		*Result.JsonFileRepositoryLoadedLayoutId);
+
+	if (!Result.JsonFileRepositoryLoadErrorMessage.IsEmpty())
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample pipeline smoke test JSON file layout repository load error: %s"),
+			*Result.JsonFileRepositoryLoadErrorMessage);
+	}
+}
+
 void LogSQLUISamplePipelineSmokeTestResult(const FSQLUISampleSmokeTestResult& Result)
 {
 	LogSQLUISamplePipelineSmokeTestJsonFixtureResult(Result);
 	LogSQLUISamplePipelineSmokeTestRepositoryResult(Result);
+	LogSQLUISamplePipelineSmokeTestJsonFileRepositoryResult(Result);
 
 	UE_LOG(
 		LogSQLUISamples,

--- a/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleSmokeTestCommandlet.cpp
+++ b/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleSmokeTestCommandlet.cpp
@@ -171,6 +171,48 @@ void LogSQLUISampleSmokeTestRepositoryResult(
 		Result.RepositoryLoadValidation);
 }
 
+void LogSQLUISampleSmokeTestJsonFileRepositoryResult(
+	const FSQLUISampleSmokeTestResult& Result)
+{
+	if (!Result.bUsedJsonFileLayoutRepository)
+	{
+		return;
+	}
+
+	UE_LOG(LogSQLUISamples, Log, TEXT("SQLUI sample smoke test JSON file layout repository selected."));
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample smoke test JSON file layout repository save %s. LayoutId='%s'"),
+		Result.bJsonFileRepositorySaveSucceeded ? TEXT("succeeded") : TEXT("failed"),
+		*Result.JsonFileRepositorySavedLayoutId);
+
+	if (!Result.JsonFileRepositorySaveErrorMessage.IsEmpty())
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample smoke test JSON file layout repository save error: %s"),
+			*Result.JsonFileRepositorySaveErrorMessage);
+	}
+
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample smoke test JSON file layout repository load %s. LayoutId='%s'"),
+		Result.bJsonFileRepositoryLoadSucceeded ? TEXT("succeeded") : TEXT("failed"),
+		*Result.JsonFileRepositoryLoadedLayoutId);
+
+	if (!Result.JsonFileRepositoryLoadErrorMessage.IsEmpty())
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample smoke test JSON file layout repository load error: %s"),
+			*Result.JsonFileRepositoryLoadErrorMessage);
+	}
+}
+
 void LogSQLUISampleSmokeTestStepErrors(
 	const TCHAR* StepName,
 	const TArray<FString>& Messages)
@@ -205,6 +247,7 @@ void LogSQLUISampleSmokeTestResult(const FSQLUISampleSmokeTestResult& Result)
 {
 	LogSQLUISampleSmokeTestJsonFixtureResult(Result);
 	LogSQLUISampleSmokeTestRepositoryResult(Result);
+	LogSQLUISampleSmokeTestJsonFileRepositoryResult(Result);
 
 	UE_LOG(
 		LogSQLUISamples,
@@ -271,10 +314,14 @@ int32 USQLUISampleSmokeTestCommandlet::Main(const FString& Params)
 	const bool bUseInMemoryLayoutRepository =
 		FParse::Param(*Params, TEXT("UseInMemoryLayoutRepository"))
 		|| FParse::Param(*Params, TEXT("InMemoryLayoutRepository"));
+	const bool bUseJsonFileLayoutRepository =
+		FParse::Param(*Params, TEXT("UseJsonFileLayoutRepository"))
+		|| FParse::Param(*Params, TEXT("JsonFileLayoutRepository"));
 	const bool bUseJsonLayoutFixture =
 		FParse::Param(*Params, TEXT("UseJsonLayoutFixture"))
 		|| FParse::Param(*Params, TEXT("JsonLayoutFixture"))
-		|| bUseInMemoryLayoutRepository;
+		|| bUseInMemoryLayoutRepository
+		|| bUseJsonFileLayoutRepository;
 
 	UE_LOG(
 		LogSQLUISamples,
@@ -287,6 +334,12 @@ int32 USQLUISampleSmokeTestCommandlet::Main(const FString& Params)
 		Log,
 		TEXT("SQLUI sample smoke test in-memory layout repository selected: %s"),
 		bUseInMemoryLayoutRepository ? TEXT("true") : TEXT("false"));
+
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample smoke test JSON file layout repository selected: %s"),
+		bUseJsonFileLayoutRepository ? TEXT("true") : TEXT("false"));
 
 	UWorld* CommandletWorld = CreateSQLUISampleSmokeTestCommandletWorld();
 	if (!CommandletWorld)
@@ -303,6 +356,7 @@ int32 USQLUISampleSmokeTestCommandlet::Main(const FString& Params)
 		FSQLUISampleSmokeTestRequest Request;
 		Request.bUseJsonLayoutFixture = bUseJsonLayoutFixture;
 		Request.bUseInMemoryLayoutRepository = bUseInMemoryLayoutRepository;
+		Request.bUseJsonFileLayoutRepository = bUseJsonFileLayoutRepository;
 		Result = USQLUISampleSmokeTestRunner::RunSmokeTest(CommandletWorld, Request);
 	}
 

--- a/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleSmokeTestRunner.cpp
+++ b/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleSmokeTestRunner.cpp
@@ -1,8 +1,11 @@
 #include "SQLUISampleSmokeTestRunner.h"
 
+#include "Layout/ISQLUILayoutRepository.h"
 #include "Layout/SQLUIInMemoryLayoutRepository.h"
+#include "Layout/SQLUIJsonFileLayoutRepository.h"
 #include "Layout/SQLUILayoutJson.h"
 #include "Layout/SQLUILayoutTypes.h"
+#include "Misc/Paths.h"
 #include "Runtime/SQLUIRuntimeContext.h"
 #include "Variables/SQLUIVariableStore.h"
 #include "Variables/SQLUIVariableTypes.h"
@@ -83,6 +86,16 @@ struct FSQLUISampleSmokeTestLayoutResult
 	FString RepositoryLoadErrorMessage;
 	FSQLUILayoutValidationResult RepositorySaveValidation;
 	FSQLUILayoutValidationResult RepositoryLoadValidation;
+	bool bUsedJsonFileLayoutRepository = false;
+	bool bJsonFileRepositorySaveSucceeded = false;
+	bool bJsonFileRepositoryLoadSucceeded = false;
+	FString JsonFileRepositorySavedLayoutId;
+	FString JsonFileRepositoryLoadedLayoutId;
+	FString JsonFileRepositorySaveErrorMessage;
+	FString JsonFileRepositoryLoadErrorMessage;
+	FSQLUILayoutValidationResult JsonFileRepositorySaveValidation;
+	FSQLUILayoutValidationResult JsonFileRepositoryLoadValidation;
+	TArray<FString> Warnings;
 	FSQLUILayoutDocument Document;
 };
 
@@ -167,16 +180,18 @@ bool DidSQLUISampleLayoutJsonParseFail(const FSQLUILayoutValidationResult& Valid
 }
 
 FSQLUILayoutSaveResult SaveSQLUISampleLayoutToRepository(
-	USQLUIInMemoryLayoutRepository* Repository,
+	ISQLUILayoutRepository* Repository,
+	const TCHAR* RepositoryName,
 	const FSQLUILayoutDocument& Document)
 {
 	FSQLUILayoutSaveResult SaveResult;
 	SaveResult.SavedLayoutId = Document.Metadata.LayoutId;
 
-	if (!IsValid(Repository))
+	if (!Repository)
 	{
-		SaveResult.ErrorMessage =
-			TEXT("SQLUI sample smoke test failed: could not create in-memory layout repository.");
+		SaveResult.ErrorMessage = FString::Printf(
+			TEXT("SQLUI sample smoke test failed: could not create %s."),
+			RepositoryName);
 		return SaveResult;
 	}
 
@@ -193,24 +208,27 @@ FSQLUILayoutSaveResult SaveSQLUISampleLayoutToRepository(
 	if (!bSaveCompleted)
 	{
 		SaveResult.bSucceeded = false;
-		SaveResult.ErrorMessage =
-			TEXT("SQLUI sample smoke test failed: in-memory layout repository save did not complete.");
+		SaveResult.ErrorMessage = FString::Printf(
+			TEXT("SQLUI sample smoke test failed: %s save did not complete."),
+			RepositoryName);
 	}
 
 	return SaveResult;
 }
 
 FSQLUILayoutLoadResult LoadSQLUISampleLayoutFromRepository(
-	USQLUIInMemoryLayoutRepository* Repository,
+	ISQLUILayoutRepository* Repository,
+	const TCHAR* RepositoryName,
 	const FString& LayoutId)
 {
 	FSQLUILayoutLoadResult LoadResult;
 	LoadResult.Document.Metadata.LayoutId = LayoutId;
 
-	if (!IsValid(Repository))
+	if (!Repository)
 	{
-		LoadResult.ErrorMessage =
-			TEXT("SQLUI sample smoke test failed: could not create in-memory layout repository.");
+		LoadResult.ErrorMessage = FString::Printf(
+			TEXT("SQLUI sample smoke test failed: could not create %s."),
+			RepositoryName);
 		return LoadResult;
 	}
 
@@ -227,11 +245,36 @@ FSQLUILayoutLoadResult LoadSQLUISampleLayoutFromRepository(
 	if (!bLoadCompleted)
 	{
 		LoadResult.bSucceeded = false;
-		LoadResult.ErrorMessage =
-			TEXT("SQLUI sample smoke test failed: in-memory layout repository load did not complete.");
+		LoadResult.ErrorMessage = FString::Printf(
+			TEXT("SQLUI sample smoke test failed: %s load did not complete."),
+			RepositoryName);
 	}
 
 	return LoadResult;
+}
+
+FString MakeSQLUISampleJsonFileLayoutRepositoryBaseDirectory()
+{
+	FString BaseDirectory = FPaths::Combine(
+		FPaths::ProjectSavedDir(),
+		TEXT("SQLUI"),
+		TEXT("SmokeTests"),
+		TEXT("Layouts"));
+	FPaths::NormalizeDirectoryName(BaseDirectory);
+	return BaseDirectory;
+}
+
+void AddSQLUISampleJsonFileRepositoryCleanupWarning(
+	FSQLUISampleSmokeTestLayoutResult& Result,
+	const FString& LayoutId,
+	const FString& BaseDirectory,
+	const FString& ErrorMessage)
+{
+	Result.Warnings.Add(FString::Printf(
+		TEXT("SQLUI sample smoke test JSON file layout repository cleanup did not remove layout id '%s' under '%s'. %s"),
+		*LayoutId,
+		*BaseDirectory,
+		*ErrorMessage));
 }
 
 FSQLUISampleSmokeTestLayoutResult ResolveSQLUISampleSmokeTestLayoutDocument(
@@ -240,8 +283,11 @@ FSQLUISampleSmokeTestLayoutResult ResolveSQLUISampleSmokeTestLayoutDocument(
 {
 	FSQLUISampleSmokeTestLayoutResult Result;
 	Result.bUsedInMemoryLayoutRepository = Request.bUseInMemoryLayoutRepository;
+	Result.bUsedJsonFileLayoutRepository = Request.bUseJsonFileLayoutRepository;
 	Result.bUsedJsonLayoutFixture =
-		Request.bUseJsonLayoutFixture || Request.bUseInMemoryLayoutRepository;
+		Request.bUseJsonLayoutFixture
+		|| Request.bUseInMemoryLayoutRepository
+		|| Request.bUseJsonFileLayoutRepository;
 
 	if (!Result.bUsedJsonLayoutFixture)
 	{
@@ -259,49 +305,134 @@ FSQLUISampleSmokeTestLayoutResult ResolveSQLUISampleSmokeTestLayoutDocument(
 	Result.bJsonLayoutFixtureValidationSucceeded =
 		Result.bJsonLayoutFixtureParseSucceeded && Result.JsonLayoutFixtureValidation.bIsValid;
 	Result.bSucceeded = bParsedAndValidated;
-	if (!Result.bSucceeded || !Request.bUseInMemoryLayoutRepository)
+	if (!Result.bSucceeded)
 	{
 		return Result;
 	}
 
-	USQLUIInMemoryLayoutRepository* LayoutRepository =
-		NewObject<USQLUIInMemoryLayoutRepository>(Outer);
-	const FSQLUILayoutSaveResult SaveResult =
-		SaveSQLUISampleLayoutToRepository(LayoutRepository, Result.Document);
-
-	Result.bRepositorySaveSucceeded = SaveResult.bSucceeded;
-	Result.SavedLayoutId = SaveResult.SavedLayoutId;
-	Result.RepositorySaveErrorMessage = SaveResult.ErrorMessage;
-	Result.RepositorySaveValidation = SaveResult.Validation;
-
-	if (!SaveResult.bSucceeded)
+	if (Request.bUseInMemoryLayoutRepository)
 	{
-		Result.bSucceeded = false;
-		return Result;
-	}
+		USQLUIInMemoryLayoutRepository* LayoutRepository =
+			NewObject<USQLUIInMemoryLayoutRepository>(Outer);
+		const FSQLUILayoutSaveResult SaveResult =
+			SaveSQLUISampleLayoutToRepository(
+				LayoutRepository,
+				TEXT("in-memory layout repository"),
+				Result.Document);
 
-	const FString LayoutId = Result.Document.Metadata.LayoutId;
-	const FSQLUILayoutLoadResult LoadResult =
-		LoadSQLUISampleLayoutFromRepository(LayoutRepository, LayoutId);
+		Result.bRepositorySaveSucceeded = SaveResult.bSucceeded;
+		Result.SavedLayoutId = SaveResult.SavedLayoutId;
+		Result.RepositorySaveErrorMessage = SaveResult.ErrorMessage;
+		Result.RepositorySaveValidation = SaveResult.Validation;
 
-	Result.bRepositoryLoadSucceeded =
-		LoadResult.bSucceeded && LoadResult.Validation.bIsValid;
-	Result.LoadedLayoutId = LoadResult.Document.Metadata.LayoutId;
-	Result.RepositoryLoadErrorMessage = LoadResult.ErrorMessage;
-	Result.RepositoryLoadValidation = LoadResult.Validation;
-
-	if (!Result.bRepositoryLoadSucceeded)
-	{
-		Result.bSucceeded = false;
-		if (Result.RepositoryLoadErrorMessage.IsEmpty())
+		if (!SaveResult.bSucceeded)
 		{
-			Result.RepositoryLoadErrorMessage =
-				TEXT("SQLUI sample smoke test failed: in-memory layout repository loaded an invalid layout document.");
+			Result.bSucceeded = false;
+			return Result;
 		}
-		return Result;
+
+		const FString LayoutId = Result.Document.Metadata.LayoutId;
+		const FSQLUILayoutLoadResult LoadResult =
+			LoadSQLUISampleLayoutFromRepository(
+				LayoutRepository,
+				TEXT("in-memory layout repository"),
+				LayoutId);
+
+		Result.bRepositoryLoadSucceeded =
+			LoadResult.bSucceeded && LoadResult.Validation.bIsValid;
+		Result.LoadedLayoutId = LoadResult.Document.Metadata.LayoutId;
+		Result.RepositoryLoadErrorMessage = LoadResult.ErrorMessage;
+		Result.RepositoryLoadValidation = LoadResult.Validation;
+
+		if (!Result.bRepositoryLoadSucceeded)
+		{
+			Result.bSucceeded = false;
+			if (Result.RepositoryLoadErrorMessage.IsEmpty())
+			{
+				Result.RepositoryLoadErrorMessage =
+					TEXT("SQLUI sample smoke test failed: in-memory layout repository loaded an invalid layout document.");
+			}
+			return Result;
+		}
+
+		Result.Document = LoadResult.Document;
 	}
 
-	Result.Document = LoadResult.Document;
+	if (Request.bUseJsonFileLayoutRepository)
+	{
+		USQLUIJsonFileLayoutRepository* LayoutRepository =
+			NewObject<USQLUIJsonFileLayoutRepository>(Outer);
+		if (IsValid(LayoutRepository))
+		{
+			FSQLUIJsonFileLayoutRepositorySettings Settings;
+			Settings.BaseDirectory = MakeSQLUISampleJsonFileLayoutRepositoryBaseDirectory();
+			LayoutRepository->Configure(Settings);
+		}
+
+		const FSQLUILayoutSaveResult SaveResult =
+			SaveSQLUISampleLayoutToRepository(
+				LayoutRepository,
+				TEXT("JSON file layout repository"),
+				Result.Document);
+
+		Result.bJsonFileRepositorySaveSucceeded = SaveResult.bSucceeded;
+		Result.JsonFileRepositorySavedLayoutId = SaveResult.SavedLayoutId;
+		Result.JsonFileRepositorySaveErrorMessage = SaveResult.ErrorMessage;
+		Result.JsonFileRepositorySaveValidation = SaveResult.Validation;
+
+		if (!SaveResult.bSucceeded)
+		{
+			Result.bSucceeded = false;
+			return Result;
+		}
+
+		const FString LayoutId = Result.Document.Metadata.LayoutId;
+		const FSQLUILayoutLoadResult LoadResult =
+			LoadSQLUISampleLayoutFromRepository(
+				LayoutRepository,
+				TEXT("JSON file layout repository"),
+				LayoutId);
+
+		Result.bJsonFileRepositoryLoadSucceeded =
+			LoadResult.bSucceeded && LoadResult.Validation.bIsValid;
+		Result.JsonFileRepositoryLoadedLayoutId = LoadResult.Document.Metadata.LayoutId;
+		Result.JsonFileRepositoryLoadErrorMessage = LoadResult.ErrorMessage;
+		Result.JsonFileRepositoryLoadValidation = LoadResult.Validation;
+
+		const FString BaseDirectory = MakeSQLUISampleJsonFileLayoutRepositoryBaseDirectory();
+		const FSQLUILayoutRepositoryRemoveResult RemoveResult =
+			LayoutRepository->RemoveLayout(LayoutId);
+		if (!RemoveResult.bSucceeded)
+		{
+			AddSQLUISampleJsonFileRepositoryCleanupWarning(
+				Result,
+				LayoutId,
+				BaseDirectory,
+				RemoveResult.ErrorMessage);
+		}
+		else if (!RemoveResult.bRemoved)
+		{
+			AddSQLUISampleJsonFileRepositoryCleanupWarning(
+				Result,
+				LayoutId,
+				BaseDirectory,
+				RemoveResult.ErrorMessage);
+		}
+
+		if (!Result.bJsonFileRepositoryLoadSucceeded)
+		{
+			Result.bSucceeded = false;
+			if (Result.JsonFileRepositoryLoadErrorMessage.IsEmpty())
+			{
+				Result.JsonFileRepositoryLoadErrorMessage =
+					TEXT("SQLUI sample smoke test failed: JSON file layout repository loaded an invalid layout document.");
+			}
+			return Result;
+		}
+
+		Result.Document = LoadResult.Document;
+	}
+
 	return Result;
 }
 
@@ -322,6 +453,13 @@ void ApplySQLUISampleLayoutResult(
 	Result.RepositoryLoadErrorMessage = LayoutResult.RepositoryLoadErrorMessage;
 	Result.RepositorySaveValidation = LayoutResult.RepositorySaveValidation;
 	Result.RepositoryLoadValidation = LayoutResult.RepositoryLoadValidation;
+	Result.bUsedJsonFileLayoutRepository = LayoutResult.bUsedJsonFileLayoutRepository;
+	Result.bJsonFileRepositorySaveSucceeded = LayoutResult.bJsonFileRepositorySaveSucceeded;
+	Result.bJsonFileRepositoryLoadSucceeded = LayoutResult.bJsonFileRepositoryLoadSucceeded;
+	Result.JsonFileRepositorySavedLayoutId = LayoutResult.JsonFileRepositorySavedLayoutId;
+	Result.JsonFileRepositoryLoadedLayoutId = LayoutResult.JsonFileRepositoryLoadedLayoutId;
+	Result.JsonFileRepositorySaveErrorMessage = LayoutResult.JsonFileRepositorySaveErrorMessage;
+	Result.JsonFileRepositoryLoadErrorMessage = LayoutResult.JsonFileRepositoryLoadErrorMessage;
 }
 
 void AddSQLUISampleLayoutValidationMessages(
@@ -362,6 +500,16 @@ FString MakeSQLUISampleLayoutFailureMessage(
 		return TEXT("SQLUI sample pipeline smoke test failed: in-memory layout repository load failed.");
 	}
 
+	if (LayoutResult.bUsedJsonFileLayoutRepository && !LayoutResult.bJsonFileRepositorySaveSucceeded)
+	{
+		return TEXT("SQLUI sample pipeline smoke test failed: JSON file layout repository save failed.");
+	}
+
+	if (LayoutResult.bUsedJsonFileLayoutRepository && !LayoutResult.bJsonFileRepositoryLoadSucceeded)
+	{
+		return TEXT("SQLUI sample pipeline smoke test failed: JSON file layout repository load failed.");
+	}
+
 	return TEXT("SQLUI sample pipeline smoke test failed: layout document could not be resolved.");
 }
 
@@ -392,7 +540,8 @@ FSQLUISampleSmokeTestResult MakeSQLUISampleSmokeTestResult(
 	Result.bSucceeded = PipelineResult.bSucceeded;
 	Result.ErrorMessage = PipelineResult.ErrorMessage;
 	Result.Errors = PipelineResult.Errors;
-	Result.Warnings = PipelineResult.Warnings;
+	Result.Warnings = LayoutResult.Warnings;
+	Result.Warnings.Append(PipelineResult.Warnings);
 	Result.StepResults = PipelineResult.StepResults;
 	Result.CreatedWidgetCount = PipelineResult.CreatedWidgets.Num();
 	Result.RootWidget = PipelineResult.RootWidget;
@@ -417,8 +566,13 @@ FSQLUISampleSmokeTestResult USQLUISampleSmokeTestRunner::RunSmokeTest(
 		AddSQLUISampleLayoutValidationMessages(Result, LayoutResult.JsonLayoutFixtureValidation);
 		AddSQLUISampleLayoutValidationMessages(Result, LayoutResult.RepositorySaveValidation);
 		AddSQLUISampleLayoutValidationMessages(Result, LayoutResult.RepositoryLoadValidation);
+		AddSQLUISampleLayoutValidationMessages(Result, LayoutResult.JsonFileRepositorySaveValidation);
+		AddSQLUISampleLayoutValidationMessages(Result, LayoutResult.JsonFileRepositoryLoadValidation);
 		AddSQLUISampleSmokeTestError(Result, LayoutResult.RepositorySaveErrorMessage);
 		AddSQLUISampleSmokeTestError(Result, LayoutResult.RepositoryLoadErrorMessage);
+		AddSQLUISampleSmokeTestError(Result, LayoutResult.JsonFileRepositorySaveErrorMessage);
+		AddSQLUISampleSmokeTestError(Result, LayoutResult.JsonFileRepositoryLoadErrorMessage);
+		Result.Warnings.Append(LayoutResult.Warnings);
 		return Result;
 	}
 

--- a/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISampleSmokeTestRunner.h
+++ b/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISampleSmokeTestRunner.h
@@ -37,6 +37,12 @@ struct SQLUISAMPLES_API FSQLUISampleSmokeTestRequest
 	bool bUseJsonLayoutFixture = false;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bUseInMemoryLayoutRepository = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bUseJsonFileLayoutRepository = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
 	FString SampleFilterText = TEXT("Smoke test");
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
@@ -65,6 +71,54 @@ struct SQLUISAMPLES_API FSQLUISampleSmokeTestResult
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
 	FSQLUILayoutValidationResult JsonLayoutFixtureValidation;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bUsedInMemoryLayoutRepository = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bRepositorySaveSucceeded = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bRepositoryLoadSucceeded = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FString SavedLayoutId;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FString LoadedLayoutId;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FString RepositorySaveErrorMessage;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FString RepositoryLoadErrorMessage;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FSQLUILayoutValidationResult RepositorySaveValidation;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FSQLUILayoutValidationResult RepositoryLoadValidation;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bUsedJsonFileLayoutRepository = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bJsonFileRepositorySaveSucceeded = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bJsonFileRepositoryLoadSucceeded = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FString JsonFileRepositorySavedLayoutId;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FString JsonFileRepositoryLoadedLayoutId;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FString JsonFileRepositorySaveErrorMessage;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FString JsonFileRepositoryLoadErrorMessage;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
 	TArray<FString> Errors;

--- a/Scripts/RunSQLUISmokeTest.ps1
+++ b/Scripts/RunSQLUISmokeTest.ps1
@@ -10,6 +10,8 @@ param(
 
 	[switch]$UseInMemoryLayoutRepository,
 
+	[switch]$UseJsonFileLayoutRepository,
+
 	[Alias('?')]
 	[switch]$Help
 )
@@ -44,6 +46,10 @@ Parameters:
       Run the JSON fixture through the SQLUISamples in-memory layout repository
       before running the runtime widget pipeline.
 
+  -UseJsonFileLayoutRepository
+      Run the JSON fixture through the SQLUICore JSON file layout repository
+      before running the runtime widget pipeline.
+
   -Help, -?
       Show this help.
 
@@ -51,6 +57,7 @@ Examples:
   .\Scripts\RunSQLUISmokeTest.ps1 -EngineRoot "C:\Program Files\Epic Games\UE_5.7"
   .\Scripts\RunSQLUISmokeTest.ps1 -EngineRoot "C:\Program Files\Epic Games\UE_5.7" -UseJsonLayoutFixture
   .\Scripts\RunSQLUISmokeTest.ps1 -EngineRoot "C:\Program Files\Epic Games\UE_5.7" -UseInMemoryLayoutRepository
+  .\Scripts\RunSQLUISmokeTest.ps1 -EngineRoot "C:\Program Files\Epic Games\UE_5.7" -UseJsonFileLayoutRepository
   .\Scripts\RunSQLUISmokeTest.ps1 -UnrealEditorCmdPath "C:\UE\Engine\Binaries\Win64\UnrealEditor-Cmd.exe"
   .\Scripts\RunSQLUISmokeTest.ps1 -EngineRoot "C:\Program Files\Epic Games\UE_5.7" -ProjectPath ".\JerryRigged.uproject"
 '@
@@ -165,6 +172,11 @@ if ($UseJsonLayoutFixture)
 if ($UseInMemoryLayoutRepository)
 {
 	$CommandletArgs += '-UseInMemoryLayoutRepository'
+}
+
+if ($UseJsonFileLayoutRepository)
+{
+	$CommandletArgs += '-UseJsonFileLayoutRepository'
 }
 
 $PrintableCommandParts = @($ResolvedUnrealEditorCmdPath) + $CommandletArgs

--- a/docs/sqlui_smoke_test.md
+++ b/docs/sqlui_smoke_test.md
@@ -6,9 +6,11 @@ By default, the smoke test uses the existing in-memory C++ layout document. It c
 
 The in-memory repository smoke path reuses that same JSON fixture, saves the deserialized layout into `USQLUIInMemoryLayoutRepository`, loads it back by layout id, and then runs the runtime widget pipeline with the loaded document.
 
+The JSON file repository smoke path also reuses the JSON fixture, saves the deserialized layout into `USQLUIJsonFileLayoutRepository`, loads it back by layout id, and then runs the runtime widget pipeline with the loaded document.
+
 This is a local developer workflow only. It is not CI yet, and it does not assume Unreal Engine is installed on GitHub Actions or any build agent.
 
-The smoke test does not edit maps, levels, Content, SQLite databases, files, or the viewport. It does not add database behavior, use SQLite, perform file I/O, or attach widgets to the viewport.
+The smoke test does not edit maps, levels, Content, SQLite databases, or the viewport. It does not add database behavior, use SQLite, or attach widgets to the viewport. The JSON file repository smoke path writes only under `Saved\SQLUI\SmokeTests\Layouts` and attempts to remove its test layout after loading it.
 
 ## Build JerryRiggedEditor
 
@@ -72,6 +74,18 @@ The commandlet also accepts `-InMemoryLayoutRepository` directly as an alias whe
 
 This path is still sample scaffolding only. It does not use SQLite, disk persistence, file I/O, maps, Content, or viewport attachment.
 
+## Run The JSON File Repository Smoke Test
+
+The JSON file repository path keeps the same transient commandlet flow, deserializes the built-in SQLUISamples JSON layout fixture, saves it into `USQLUIJsonFileLayoutRepository`, loads it back by `LayoutId`, and runs the same runtime widget pipeline with the loaded layout document:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\RunSQLUISmokeTest.ps1 -EngineRoot "C:\Program Files\Epic Games\UE_5.7" -UseJsonFileLayoutRepository
+```
+
+The commandlet also accepts `-JsonFileLayoutRepository` directly as an alias when invoking `UnrealEditor-Cmd.exe`.
+
+This path is still sample scaffolding only. It does not use SQLite, Content, maps, or viewport attachment. It writes the temporary layout file under `Saved\SQLUI\SmokeTests\Layouts` and attempts to remove it after the load step. If cleanup cannot remove the file, the warning log names that Saved path.
+
 ## Expected Results
 
 The script prints the exact command it runs, then returns the same exit code as the commandlet. It passes `-DDC-AllowNoActiveStores` so this transient smoke-test commandlet does not require a writable local Derived Data Cache.
@@ -106,6 +120,20 @@ SQLUI sample smoke test JSON fixture validation succeeded.
 SQLUI sample smoke test in-memory layout repository selected.
 SQLUI sample smoke test in-memory layout repository save succeeded.
 SQLUI sample smoke test in-memory layout repository load succeeded.
+SQLUI sample smoke test commandlet succeeded.
+SQLUI sample smoke test root widget valid: true
+SQLUI sample smoke test created widget count: 1
+```
+
+For the JSON file repository smoke test, also look for:
+
+```text
+SQLUI sample smoke test JSON fixture selected: true
+SQLUI sample smoke test JSON fixture parse succeeded.
+SQLUI sample smoke test JSON fixture validation succeeded.
+SQLUI sample smoke test JSON file layout repository selected.
+SQLUI sample smoke test JSON file layout repository save succeeded.
+SQLUI sample smoke test JSON file layout repository load succeeded.
 SQLUI sample smoke test commandlet succeeded.
 SQLUI sample smoke test root widget valid: true
 SQLUI sample smoke test created widget count: 1


### PR DESCRIPTION
Summary
- Added a JSON file repository smoke-test path to SQLUISamples
- Deserializes the JSON layout fixture and saves it into USQLUIJsonFileLayoutRepository
- Loads the layout back from the JSON file repository and runs the SQLUI runtime widget pipeline
- Added commandlet/script support for the JSON file repository smoke path
- Updated smoke test docs with JSON file repository usage

Validation
- Ran git diff --check
- Built JerryRiggedEditor Win64 Development successfully
- Ran the default SQLUI smoke test script successfully
- Ran the JSON fixture SQLUI smoke test script successfully
- Ran the in-memory repository SQLUI smoke test script successfully
- Ran the JSON file repository SQLUI smoke test script successfully

Notes
- Does not add SQLite/database behavior
- Does not edit maps or Content
- Does not attach widgets to viewport
- Does not touch JerryRigged host code
- Writes only to the local Saved/SQLUI/SmokeTests/Layouts path for the smoke test
- Proves JSON file-backed repository loading before SQLite-backed layout loading