### PR TITLE
Document SQLUI repository architecture

### DIFF
--- a/PROJECT_BRIEF.md
+++ b/PROJECT_BRIEF.md
@@ -28,6 +28,8 @@ SQLUI / JerryRigged is a reusable Unreal Engine plugin plus host app that builds
 - `SQLUI.Samples` owns minimal sample host scaffolding and later sample assets.
 - `JerryRigged` stays a thin host project layer.
 
+Related architecture doc: [SQLUI repository architecture](docs/sqlui_repository_architecture.md).
+
 ## First Success Criteria
 - The `SQLUI` plugin and three milestone-1 modules exist.
 - Project and plugin registration are in place.

--- a/docs/sqlui_repository_architecture.md
+++ b/docs/sqlui_repository_architecture.md
@@ -1,0 +1,144 @@
+# SQLUI Repository Architecture
+
+SQLUI layout persistence sits behind repository interfaces. Runtime widget code should ask for validated layout documents through repositories and related runtime services. It should not issue raw SQL, know database table shapes, or choose storage backends directly.
+
+This boundary keeps `SQLUI.Widgets` focused on building and updating UMG widgets, keeps `SQLUI.Core` responsible for data access contracts, and lets the project swap storage implementations without rewriting widget or runtime pipeline code.
+
+## Repository Boundary
+
+`ISQLUILayoutRepository` is the current layout repository contract. It exposes:
+
+- `LoadLayout(LayoutId, Callback)`
+- `SaveLayout(Document, Callback)`
+
+The callback shape is important even while the current concrete repositories complete immediately. Future persistent repositories can use the same contract while doing database or file work through appropriate background boundaries.
+
+Widgets, widget factories, and runtime pipeline code should depend on layout documents, repositories, variable stores, action systems, and runtime context objects. They should not depend on raw SQL strings, SQLite connection objects, table names, or direct file paths.
+
+## Current Repositories
+
+### `USQLUILayoutRepository`
+
+`USQLUILayoutRepository` is the base `UObject` implementation of the repository contract. It is intentionally unavailable by default.
+
+Its `LoadLayout` and `SaveLayout` methods return failure results with `bBackendUnavailable = true`, `bSucceeded = false`, and an explanatory `ErrorMessage`. This gives callers a safe default while a concrete backend is not configured or not implemented.
+
+Use this behavior to make unavailable persistence explicit. Do not treat it as a storage implementation.
+
+### `USQLUIInMemoryLayoutRepository`
+
+`USQLUIInMemoryLayoutRepository` is transient test and development storage. It keeps `FSQLUILayoutDocument` values in a transient map keyed by `Metadata.LayoutId`.
+
+It validates documents before save, supports load by layout id, supports load by display name, and has list, remove, and clear helpers. Data lives only for the lifetime of the repository object.
+
+This repository is useful for smoke tests, sample flows, and temporary runtime experiments where persistence is not required. It should not be used as durable user layout storage.
+
+### `USQLUIJsonFileLayoutRepository`
+
+`USQLUIJsonFileLayoutRepository` is runtime-writable JSON persistence. It serializes validated `FSQLUILayoutDocument` values with `FSQLUILayoutJson` and writes one UTF-8 JSON file per layout id.
+
+By default, it resolves its base directory to:
+
+```text
+Saved/SQLUI/Layouts
+```
+
+The base directory can be configured through `FSQLUIJsonFileLayoutRepositorySettings`. Layout ids must be non-empty and safe to use as file names. The repository creates its target directory when saving, loads documents back through the same JSON validation path, lists `*.json` layouts as metadata, and can remove or clear stored layout files.
+
+This repository is suitable for lightweight runtime persistence and local development workflows. It is not a replacement for the future SQLite-backed persistence path.
+
+## Result Types
+
+Load and save result types live in `Plugins/SQLUI/Source/SQLUICore/Public/Layout/SQLUILayoutTypes.h`.
+
+`FSQLUILayoutLoadResult` includes:
+
+- `bSucceeded`
+- `bBackendUnavailable`
+- `ErrorMessage`
+- `Document`
+- `Validation`
+
+`FSQLUILayoutSaveResult` includes:
+
+- `bSucceeded`
+- `bBackendUnavailable`
+- `ErrorMessage`
+- `SavedLayoutId`
+- `Validation`
+
+List, remove, and clear result types live in `Plugins/SQLUI/Source/SQLUICore/Public/Layout/SQLUILayoutRepository.h`.
+
+`FSQLUILayoutRepositoryListResult` includes `bSucceeded`, `ErrorMessage`, and a `Layouts` metadata array.
+
+`FSQLUILayoutRepositoryRemoveResult` includes `bSucceeded`, `ErrorMessage`, `RemovedLayoutId`, and `bRemoved`. `bRemoved` distinguishes a successful no-op from a successful delete.
+
+`FSQLUILayoutRepositoryClearResult` includes `bSucceeded`, `ErrorMessage`, and `RemovedCount`.
+
+Repository implementations should preserve these result semantics:
+
+- `bSucceeded` tells the caller whether the requested operation completed successfully.
+- `bBackendUnavailable` should mean the storage backend itself is unavailable, not merely that a layout id was missing or validation failed.
+- `ErrorMessage` should explain failures and useful no-op warnings.
+- Validation payloads should travel with load and save results whenever validation was attempted.
+- Metadata arrays should be enough for layout pickers and search screens to show available layouts without loading widget trees directly.
+- Removal counts should report how much state a clear operation actually deleted.
+
+## Runtime Persistence Paths
+
+Runtime-writable layout state belongs under `Saved/SQLUI/...`.
+
+The JSON file layout repository defaults to:
+
+```text
+Saved/SQLUI/Layouts
+```
+
+The SQLUISamples JSON file repository smoke path configures:
+
+```text
+Saved/SQLUI/SmokeTests/Layouts
+```
+
+`Content/` and maps or levels are not runtime persistence stores. They should not be used for user-edited layouts, smoke-test writes, generated layout saves, or future SQLite database writes.
+
+Future seed data may live in source-controlled project or plugin locations, but writable runtime copies should still be made under `Saved` before mutation.
+
+## Current Smoke-Test Paths
+
+The local smoke-test workflow is documented in `docs/sqlui_smoke_test.md`.
+
+Current paths are:
+
+- Default in-memory C++ document: the sample runner creates a minimal `FSQLUILayoutDocument` in code and runs the widget pipeline.
+- JSON fixture: SQLUISamples parses and validates a built-in JSON layout fixture, then runs the same widget pipeline.
+- In-memory repository round trip: the JSON fixture is saved into `USQLUIInMemoryLayoutRepository`, loaded back by layout id, and passed into the widget pipeline.
+- JSON file repository round trip: the JSON fixture is saved into `USQLUIJsonFileLayoutRepository`, loaded back by layout id, removed from `Saved/SQLUI/SmokeTests/Layouts`, and passed into the widget pipeline.
+
+These paths do not use SQLite, Content, maps, viewport attachment, or durable project assets.
+
+## Future SQLite Repository Direction
+
+A future SQLite-backed layout repository should sit behind the same repository contract as the current implementations. Callers should be able to request, save, list, remove, and clear layouts without knowing whether the backing store is in memory, JSON files, or SQLite.
+
+The SQLite implementation should:
+
+- Use async or background database boundaries. Database work must not run on the game thread.
+- Keep SQL and table details inside `SQLUI.Core`, not in widgets or sample callers.
+- Return the same result types and honor the same `bSucceeded`, `bBackendUnavailable`, `ErrorMessage`, and validation semantics.
+- Fit the planned `Layouts.db` persistence path and gracefully report unavailable backend state when SQLite is disabled or missing.
+- Support later layout lifecycle work such as revisions, history, checkpoints, tags, search metadata, and preview sessions.
+- Preserve the current document validation boundary before saving and after loading.
+- Use `Saved/SQLUI/...` for writable runtime database state, with any seed-copy behavior handled before mutation.
+
+SQLite is intentionally not implemented as part of this documentation task. Choosing a concrete SQLite backend, adding schema, wiring migrations, and expanding smoke coverage should happen in later implementation work.
+
+## Suggested Next Steps
+
+Near-term implementation work can stay small and repository-focused:
+
+1. Add smoke coverage for list, remove, and clear behavior on existing repositories.
+2. Define how runtime code selects a repository implementation without coupling widgets to concrete storage.
+3. Draft the future SQLite layout schema before choosing or integrating a backend.
+4. Add the SQLite repository only after async boundaries, backend selection, and `Saved` database copy behavior are agreed.
+5. Extend lifecycle features through repository contracts instead of exposing storage details to widgets.


### PR DESCRIPTION
Summary
- Added SQLUI repository architecture documentation
- Documented the repository boundary and current repository implementations
- Explained in-memory, JSON file-backed, and future SQLite repository roles
- Documented result types and runtime persistence rules
- Linked the repository architecture doc from PROJECT_BRIEF.md

Validation
- Ran git diff --check
- Reviewed docs-only diff

Notes
- Documentation only
- No C++ source changes
- No Content or map changes
- No SQLite implementation
- Establishes guidance before adding SQLite-backed persistence