### PR TITLE
Add minimal native SQLUI filter box widget

### DIFF
--- a/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIFilterBox.cpp
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIFilterBox.cpp
@@ -1,8 +1,12 @@
 #include "Widgets/SQLUIFilterBox.h"
 
+#include "Blueprint/WidgetTree.h"
+#include "Components/EditableTextBox.h"
+
 void USQLUIFilterBox::SetFilterText(const FText& InFilterText)
 {
 	FilterText = InFilterText;
+	SyncFilterTextBoxText();
 	NativeOnFilterTextChanged(FilterText);
 }
 
@@ -14,6 +18,23 @@ FText USQLUIFilterBox::GetFilterText() const
 void USQLUIFilterBox::ClearFilterText()
 {
 	SetFilterText(FText::GetEmpty());
+}
+
+void USQLUIFilterBox::SetPlaceholderText(const FText& InPlaceholderText)
+{
+	PlaceholderText = InPlaceholderText;
+	SyncFilterTextBoxPlaceholderText();
+}
+
+FText USQLUIFilterBox::GetPlaceholderText() const
+{
+	return PlaceholderText;
+}
+
+void USQLUIFilterBox::NativeOnSQLUIWidgetInitialized()
+{
+	Super::NativeOnSQLUIWidgetInitialized();
+	EnsureFilterTextBox();
 }
 
 void USQLUIFilterBox::NativeOnFilterTextChanged(const FText& InFilterText)
@@ -32,9 +53,81 @@ bool USQLUIFilterBox::NativeApplySQLUIWidgetProperty(
 		return true;
 	}
 
+	if (PropertyName == TEXT("PlaceholderText"))
+	{
+		SetPlaceholderText(FText::FromString(PropertyValue));
+		return true;
+	}
+
 	return Super::NativeApplySQLUIWidgetProperty(
 		PropertyName,
 		PropertyValue,
 		OutFailureMessage,
 		bOutUnsupportedProperty);
+}
+
+void USQLUIFilterBox::HandleFilterTextBoxTextChanged(const FText& InText)
+{
+	if (bSyncingFilterTextToTextBox)
+	{
+		return;
+	}
+
+	SetFilterText(InText);
+}
+
+void USQLUIFilterBox::EnsureFilterTextBox()
+{
+	if (IsValid(FilterTextBox.Get()) || !WidgetTree)
+	{
+		return;
+	}
+
+	if (UEditableTextBox* ExistingRootTextBox = Cast<UEditableTextBox>(WidgetTree->RootWidget))
+	{
+		FilterTextBox = ExistingRootTextBox;
+	}
+	else if (!WidgetTree->RootWidget)
+	{
+		FilterTextBox = WidgetTree->ConstructWidget<UEditableTextBox>(
+			UEditableTextBox::StaticClass(),
+			TEXT("SQLUIFilterTextBox"));
+		WidgetTree->RootWidget = FilterTextBox.Get();
+	}
+
+	if (!IsValid(FilterTextBox.Get()))
+	{
+		return;
+	}
+
+	FilterTextBox->OnTextChanged.RemoveDynamic(this, &USQLUIFilterBox::HandleFilterTextBoxTextChanged);
+	FilterTextBox->OnTextChanged.AddDynamic(this, &USQLUIFilterBox::HandleFilterTextBoxTextChanged);
+
+	SyncFilterTextBoxText();
+	SyncFilterTextBoxPlaceholderText();
+}
+
+void USQLUIFilterBox::SyncFilterTextBoxText()
+{
+	if (!IsValid(FilterTextBox.Get()))
+	{
+		return;
+	}
+
+	if (FilterTextBox->GetText().ToString() == FilterText.ToString())
+	{
+		return;
+	}
+
+	bSyncingFilterTextToTextBox = true;
+	FilterTextBox->SetText(FilterText);
+	bSyncingFilterTextToTextBox = false;
+}
+
+void USQLUIFilterBox::SyncFilterTextBoxPlaceholderText()
+{
+	if (IsValid(FilterTextBox.Get()))
+	{
+		FilterTextBox->SetHintText(PlaceholderText);
+	}
 }

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIFilterBox.h
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIFilterBox.h
@@ -5,6 +5,8 @@
 
 #include "SQLUIFilterBox.generated.h"
 
+class UEditableTextBox;
+
 UCLASS(BlueprintType, Blueprintable)
 class SQLUIWIDGETS_API USQLUIFilterBox : public USQLUIBaseWidget
 {
@@ -20,7 +22,14 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "SQLUI|Filter")
 	void ClearFilterText();
 
+	UFUNCTION(BlueprintCallable, Category = "SQLUI|Filter")
+	void SetPlaceholderText(const FText& InPlaceholderText);
+
+	UFUNCTION(BlueprintPure, Category = "SQLUI|Filter")
+	FText GetPlaceholderText() const;
+
 protected:
+	virtual void NativeOnSQLUIWidgetInitialized() override;
 	virtual void NativeOnFilterTextChanged(const FText& InFilterText);
 	virtual bool NativeApplySQLUIWidgetProperty(
 		const FString& PropertyName,
@@ -29,6 +38,21 @@ protected:
 		bool& bOutUnsupportedProperty) override;
 
 private:
+	UFUNCTION()
+	void HandleFilterTextBoxTextChanged(const FText& InText);
+
+	void EnsureFilterTextBox();
+	void SyncFilterTextBoxText();
+	void SyncFilterTextBoxPlaceholderText();
+
 	UPROPERTY(Transient, BlueprintReadOnly, Category = "SQLUI|Filter", meta = (AllowPrivateAccess = "true"))
 	FText FilterText;
+
+	UPROPERTY(Transient, BlueprintReadOnly, Category = "SQLUI|Filter", meta = (AllowPrivateAccess = "true"))
+	FText PlaceholderText;
+
+	UPROPERTY(Transient)
+	TObjectPtr<UEditableTextBox> FilterTextBox = nullptr;
+
+	bool bSyncingFilterTextToTextBox = false;
 };


### PR DESCRIPTION
Summary
- Added a minimal native UMG visual implementation for USQLUIFilterBox
- Creates a UEditableTextBox for the filter box visual content
- Keeps FilterText synchronized with the editable text box
- Adds basic PlaceholderText support
- Keeps IsEnabled handled through the existing base widget property path

Validation
- Ran git diff --check
- Built JerryRiggedEditor Win64 Development successfully
- Ran existing SQLUI smoke test successfully

Notes
- Does not edit maps or Content
- Does not add Blueprint assets
- Does not attach widgets to viewport
- Does not add SQLite/database behavior
- Does not touch SQLUICore or SQLUISamples