### PR TITLE
Add SQLUI visual pipeline demo actor

### DIFF
--- a/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleVisualPipelineDemoActor.cpp
+++ b/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleVisualPipelineDemoActor.cpp
@@ -1,0 +1,115 @@
+#include "SQLUISampleVisualPipelineDemoActor.h"
+
+#include "SQLUISamplesModule.h"
+#include "Engine/World.h"
+#include "Widgets/SQLUIBaseWidget.h"
+
+namespace
+{
+const TCHAR* SQLUISampleVisualPipelineDemoBoolToString(const bool bValue)
+{
+	return bValue ? TEXT("true") : TEXT("false");
+}
+
+void LogSQLUISampleVisualPipelineDemoErrors(const TArray<FString>& Messages)
+{
+	for (const FString& Message : Messages)
+	{
+		UE_LOG(LogSQLUISamples, Error, TEXT("SQLUI sample visual pipeline demo error: %s"), *Message);
+	}
+}
+
+void LogSQLUISampleVisualPipelineDemoWarnings(const TArray<FString>& Messages)
+{
+	for (const FString& Message : Messages)
+	{
+		UE_LOG(LogSQLUISamples, Warning, TEXT("SQLUI sample visual pipeline demo warning: %s"), *Message);
+	}
+}
+}
+
+ASQLUISampleVisualPipelineDemoActor::ASQLUISampleVisualPipelineDemoActor()
+{
+	PrimaryActorTick.bCanEverTick = false;
+}
+
+void ASQLUISampleVisualPipelineDemoActor::BeginPlay()
+{
+	Super::BeginPlay();
+
+	if (bRunOnBeginPlay)
+	{
+		RunVisualPipelineDemo();
+	}
+}
+
+void ASQLUISampleVisualPipelineDemoActor::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+	if (IsValid(AddedRootWidget.Get()))
+	{
+		AddedRootWidget->RemoveFromParent();
+		AddedRootWidget = nullptr;
+	}
+
+	Super::EndPlay(EndPlayReason);
+}
+
+void ASQLUISampleVisualPipelineDemoActor::RunVisualPipelineDemo()
+{
+	if (IsValid(AddedRootWidget.Get()))
+	{
+		AddedRootWidget->RemoveFromParent();
+		AddedRootWidget = nullptr;
+	}
+
+	FSQLUISampleSmokeTestRequest Request = DemoRequest;
+	if (!IsValid(Request.OwningPlayer.Get()) && GetWorld())
+	{
+		Request.OwningPlayer = GetWorld()->GetFirstPlayerController();
+	}
+
+	LastResult = USQLUISampleSmokeTestRunner::RunSmokeTest(this, Request);
+
+	if (LastResult.bSucceeded)
+	{
+		UE_LOG(LogSQLUISamples, Log, TEXT("SQLUI sample visual pipeline demo succeeded."));
+	}
+	else
+	{
+		UE_LOG(LogSQLUISamples, Error, TEXT("SQLUI sample visual pipeline demo failed."));
+	}
+
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample visual pipeline demo created widget count: %d"),
+		LastResult.CreatedWidgetCount);
+
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample visual pipeline demo root widget valid: %s"),
+		SQLUISampleVisualPipelineDemoBoolToString(LastResult.bRootWidgetValid));
+
+	bool bAddedToViewport = false;
+	if (bAddToViewport)
+	{
+		if (IsValid(LastResult.RootWidget.Get()))
+		{
+			LastResult.RootWidget->AddToViewport(ViewportZOrder);
+			AddedRootWidget = LastResult.RootWidget;
+			bAddedToViewport = true;
+		}
+	}
+
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample visual pipeline demo viewport add status: %s"),
+		bAddToViewport
+			? (bAddedToViewport ? TEXT("added") : TEXT("failed"))
+			: TEXT("skipped"));
+
+	LogSQLUISampleVisualPipelineDemoErrors(LastResult.Errors);
+	LogSQLUISampleVisualPipelineDemoWarnings(LastResult.Warnings);
+}

--- a/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISampleVisualPipelineDemoActor.h
+++ b/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISampleVisualPipelineDemoActor.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "SQLUISampleSmokeTestRunner.h"
+
+#include "SQLUISampleVisualPipelineDemoActor.generated.h"
+
+class USQLUIBaseWidget;
+
+UCLASS(BlueprintType)
+class SQLUISAMPLES_API ASQLUISampleVisualPipelineDemoActor : public AActor
+{
+	GENERATED_BODY()
+
+public:
+	ASQLUISampleVisualPipelineDemoActor();
+
+	UFUNCTION(BlueprintCallable, Category = "SQLUI|Samples")
+	void RunVisualPipelineDemo();
+
+protected:
+	virtual void BeginPlay() override;
+	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+public:
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bRunOnBeginPlay = true;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bAddToViewport = true;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	int32 ViewportZOrder = 0;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FSQLUISampleSmokeTestRequest DemoRequest;
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Transient, Category = "SQLUI|Samples")
+	FSQLUISampleSmokeTestResult LastResult;
+
+private:
+	UPROPERTY(Transient)
+	TObjectPtr<USQLUIBaseWidget> AddedRootWidget = nullptr;
+};

--- a/Plugins/SQLUI/Source/SQLUISamples/SQLUISamples.Build.cs
+++ b/Plugins/SQLUI/Source/SQLUISamples/SQLUISamples.Build.cs
@@ -14,5 +14,10 @@ public class SQLUISamples : ModuleRules
 			"SQLUICore",
 			"SQLUIWidgets"
 		});
+
+		PrivateDependencyModuleNames.AddRange(new string[]
+		{
+			"UMG"
+		});
 	}
 }


### PR DESCRIPTION
Summary
- Added a SQLUISamples visual pipeline demo actor
- Runs the existing SQLUI smoke-test/runtime pipeline in Play mode
- Adds the generated root widget to the viewport when requested
- Removes the added widget on EndPlay
- Logs success/failure, root widget validity, created widget count, and viewport add status

Validation
- Ran git diff --check
- Built JerryRiggedEditor Win64 Development successfully
- Ran existing SQLUI smoke test successfully

Notes
- Does not edit maps or Content
- Does not add Blueprint assets
- Does not add SQLite/database behavior
- Does not touch JerryRigged host code
- Intended for manual Play-in-Editor visual verification