### PR TITLE
Improve SQLUI FilterBox visibility and demo placement

### DIFF
--- a/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleVisualPipelineDemoActor.cpp
+++ b/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleVisualPipelineDemoActor.cpp
@@ -97,6 +97,14 @@ void ASQLUISampleVisualPipelineDemoActor::RunVisualPipelineDemo()
 		if (IsValid(LastResult.RootWidget.Get()))
 		{
 			LastResult.RootWidget->AddToViewport(ViewportZOrder);
+			if (bApplyViewportPlacement)
+			{
+				LastResult.RootWidget->SetPositionInViewport(ViewportPosition, true);
+				if (ViewportSize.X > 0.0f && ViewportSize.Y > 0.0f)
+				{
+					LastResult.RootWidget->SetDesiredSizeInViewport(ViewportSize);
+				}
+			}
 			AddedRootWidget = LastResult.RootWidget;
 			bAddedToViewport = true;
 		}

--- a/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISampleVisualPipelineDemoActor.h
+++ b/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISampleVisualPipelineDemoActor.h
@@ -34,6 +34,15 @@ public:
 	int32 ViewportZOrder = 0;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bApplyViewportPlacement = true;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FVector2D ViewportPosition = FVector2D(24.0f, 24.0f);
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FVector2D ViewportSize = FVector2D(360.0f, 64.0f);
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
 	FSQLUISampleSmokeTestRequest DemoRequest;
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Transient, Category = "SQLUI|Samples")

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIFilterBox.cpp
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIFilterBox.cpp
@@ -1,7 +1,45 @@
 #include "Widgets/SQLUIFilterBox.h"
 
 #include "Blueprint/WidgetTree.h"
+#include "Brushes/SlateColorBrush.h"
+#include "Components/Border.h"
 #include "Components/EditableTextBox.h"
+
+namespace
+{
+void ApplySQLUIFilterBoxVisualDefaults(UEditableTextBox& FilterTextBox)
+{
+	const FLinearColor TextColor(0.95f, 0.97f, 1.0f, 1.0f);
+	const FLinearColor DisabledTextColor(0.72f, 0.76f, 0.82f, 1.0f);
+	const FLinearColor BackgroundColor(0.035f, 0.045f, 0.06f, 0.98f);
+	const FLinearColor HoveredBackgroundColor(0.055f, 0.07f, 0.095f, 1.0f);
+	const FLinearColor FocusedBackgroundColor(0.07f, 0.085f, 0.115f, 1.0f);
+
+	FEditableTextBoxStyle TextBoxStyle = FilterTextBox.GetWidgetStyle();
+	TextBoxStyle
+		.SetBackgroundImageNormal(FSlateColorBrush(BackgroundColor))
+		.SetBackgroundImageHovered(FSlateColorBrush(HoveredBackgroundColor))
+		.SetBackgroundImageFocused(FSlateColorBrush(FocusedBackgroundColor))
+		.SetBackgroundImageReadOnly(FSlateColorBrush(BackgroundColor))
+		.SetBackgroundColor(FSlateColor(FLinearColor::White))
+		.SetForegroundColor(FSlateColor(TextColor))
+		.SetFocusedForegroundColor(FSlateColor(TextColor))
+		.SetReadOnlyForegroundColor(FSlateColor(DisabledTextColor))
+		.SetPadding(FMargin(10.0f, 6.0f));
+
+	FilterTextBox.SetWidgetStyle(TextBoxStyle);
+	FilterTextBox.SetForegroundColor(TextColor);
+	FilterTextBox.SetMinDesiredWidth(280.0f);
+}
+
+void ApplySQLUIFilterBoxBorderVisualDefaults(UBorder& Border)
+{
+	Border.SetBrush(FSlateColorBrush(FLinearColor(0.015f, 0.02f, 0.03f, 0.92f)));
+	Border.SetBrushColor(FLinearColor::White);
+	Border.SetContentColorAndOpacity(FLinearColor::White);
+	Border.SetPadding(FMargin(8.0f));
+}
+}
 
 void USQLUIFilterBox::SetFilterText(const FText& InFilterText)
 {
@@ -89,16 +127,27 @@ void USQLUIFilterBox::EnsureFilterTextBox()
 	}
 	else if (!WidgetTree->RootWidget)
 	{
+		UBorder* FilterBorder = WidgetTree->ConstructWidget<UBorder>(
+			UBorder::StaticClass(),
+			TEXT("SQLUIFilterBorder"));
 		FilterTextBox = WidgetTree->ConstructWidget<UEditableTextBox>(
 			UEditableTextBox::StaticClass(),
 			TEXT("SQLUIFilterTextBox"));
-		WidgetTree->RootWidget = FilterTextBox.Get();
+
+		if (IsValid(FilterBorder) && IsValid(FilterTextBox.Get()))
+		{
+			ApplySQLUIFilterBoxBorderVisualDefaults(*FilterBorder);
+			FilterBorder->SetContent(FilterTextBox.Get());
+			WidgetTree->RootWidget = FilterBorder;
+		}
 	}
 
 	if (!IsValid(FilterTextBox.Get()))
 	{
 		return;
 	}
+
+	ApplySQLUIFilterBoxVisualDefaults(*FilterTextBox);
 
 	FilterTextBox->OnTextChanged.RemoveDynamic(this, &USQLUIFilterBox::HandleFilterTextBoxTextChanged);
 	FilterTextBox->OnTextChanged.AddDynamic(this, &USQLUIFilterBox::HandleFilterTextBoxTextChanged);


### PR DESCRIPTION
Summary
- Improved the native SQLUI FilterBox visual styling for readability
- Added a simple border/background/padding treatment for generated FilterBox widgets
- Added configurable viewport placement and size options to the visual demo actor
- Keeps the demo actor cleanup behavior on EndPlay

Validation
- Ran git diff --check
- Built JerryRiggedEditor Win64 Development successfully
- Manually tested Play-in-Editor visual demo

Notes
- Does not edit maps or Content
- Does not add Blueprint assets
- Does not add SQLite/database behavior
- Does not touch SQLUICore
- Leaves any dirty NewWorld.umap changes unstaged