### PR TITLE
Add minimal native visuals for SQLUI list widgets

### DIFF
--- a/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIListItemWidget.cpp
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIListItemWidget.cpp
@@ -1,5 +1,53 @@
 #include "Widgets/SQLUIListItemWidget.h"
 
+#include "Blueprint/WidgetTree.h"
+#include "Brushes/SlateColorBrush.h"
+#include "Components/Border.h"
+#include "Components/TextBlock.h"
+#include "Components/VerticalBox.h"
+#include "Components/VerticalBoxSlot.h"
+
+namespace
+{
+FText ResolveSQLUIListItemDisplayText(const FSQLUIListItemData& ListItemData)
+{
+	if (ListItemData.DisplayText.ToString().TrimStartAndEnd().IsEmpty())
+	{
+		return NSLOCTEXT("SQLUIWidgets", "SQLUIListItemUntitled", "Untitled item");
+	}
+
+	return ListItemData.DisplayText;
+}
+
+void ApplySQLUIListItemBorderDefaults(UBorder& Border)
+{
+	Border.SetBrush(FSlateColorBrush(FLinearColor(0.045f, 0.055f, 0.075f, 0.98f)));
+	Border.SetBrushColor(FLinearColor::White);
+	Border.SetContentColorAndOpacity(FLinearColor::White);
+	Border.SetPadding(FMargin(10.0f, 8.0f));
+}
+
+void ApplySQLUIListItemDisplayTextDefaults(UTextBlock& TextBlock)
+{
+	FSlateFontInfo FontInfo = TextBlock.GetFont();
+	FontInfo.Size = 15;
+
+	TextBlock.SetFont(FontInfo);
+	TextBlock.SetColorAndOpacity(FSlateColor(FLinearColor(0.94f, 0.96f, 1.0f, 1.0f)));
+	TextBlock.SetAutoWrapText(true);
+}
+
+void ApplySQLUIListItemIdTextDefaults(UTextBlock& TextBlock)
+{
+	FSlateFontInfo FontInfo = TextBlock.GetFont();
+	FontInfo.Size = 11;
+
+	TextBlock.SetFont(FontInfo);
+	TextBlock.SetColorAndOpacity(FSlateColor(FLinearColor(0.62f, 0.68f, 0.78f, 1.0f)));
+	TextBlock.SetAutoWrapText(true);
+}
+}
+
 void USQLUIListItemWidget::SetListItemData(const FSQLUIListItemData& InListItemData)
 {
 	ListItemData = InListItemData;
@@ -11,8 +59,24 @@ FSQLUIListItemData USQLUIListItemWidget::GetListItemData() const
 	return ListItemData;
 }
 
+void USQLUIListItemWidget::NativeOnInitialized()
+{
+	Super::NativeOnInitialized();
+	EnsureVisualRoot();
+	SyncVisualState();
+}
+
+void USQLUIListItemWidget::NativeOnSQLUIWidgetInitialized()
+{
+	Super::NativeOnSQLUIWidgetInitialized();
+	EnsureVisualRoot();
+	SyncVisualState();
+}
+
 void USQLUIListItemWidget::NativeOnListItemDataChanged()
 {
+	EnsureVisualRoot();
+	SyncVisualState();
 }
 
 bool USQLUIListItemWidget::NativeApplySQLUIWidgetProperty(
@@ -42,4 +106,75 @@ bool USQLUIListItemWidget::NativeApplySQLUIWidgetProperty(
 		PropertyValue,
 		OutFailureMessage,
 		bOutUnsupportedProperty);
+}
+
+void USQLUIListItemWidget::EnsureVisualRoot()
+{
+	if (IsValid(DisplayTextBlock.Get()) || !WidgetTree)
+	{
+		return;
+	}
+
+	if (UTextBlock* ExistingRootTextBlock = Cast<UTextBlock>(WidgetTree->RootWidget))
+	{
+		DisplayTextBlock = ExistingRootTextBlock;
+		ApplySQLUIListItemDisplayTextDefaults(*DisplayTextBlock);
+		return;
+	}
+
+	if (WidgetTree->RootWidget)
+	{
+		return;
+	}
+
+	ItemBorder = WidgetTree->ConstructWidget<UBorder>(
+		UBorder::StaticClass(),
+		TEXT("SQLUIListItemBorder"));
+	ItemTextContainer = WidgetTree->ConstructWidget<UVerticalBox>(
+		UVerticalBox::StaticClass(),
+		TEXT("SQLUIListItemTextContainer"));
+	DisplayTextBlock = WidgetTree->ConstructWidget<UTextBlock>(
+		UTextBlock::StaticClass(),
+		TEXT("SQLUIListItemDisplayText"));
+	ItemIdTextBlock = WidgetTree->ConstructWidget<UTextBlock>(
+		UTextBlock::StaticClass(),
+		TEXT("SQLUIListItemIdText"));
+
+	if (!IsValid(ItemBorder.Get())
+		|| !IsValid(ItemTextContainer.Get())
+		|| !IsValid(DisplayTextBlock.Get())
+		|| !IsValid(ItemIdTextBlock.Get()))
+	{
+		return;
+	}
+
+	ApplySQLUIListItemBorderDefaults(*ItemBorder);
+	ApplySQLUIListItemDisplayTextDefaults(*DisplayTextBlock);
+	ApplySQLUIListItemIdTextDefaults(*ItemIdTextBlock);
+
+	if (UVerticalBoxSlot* DisplayTextSlot = ItemTextContainer->AddChildToVerticalBox(DisplayTextBlock.Get()))
+	{
+		DisplayTextSlot->SetPadding(FMargin(0.0f, 0.0f, 0.0f, 2.0f));
+	}
+	ItemTextContainer->AddChildToVerticalBox(ItemIdTextBlock.Get());
+
+	ItemBorder->SetContent(ItemTextContainer.Get());
+	WidgetTree->RootWidget = ItemBorder.Get();
+}
+
+void USQLUIListItemWidget::SyncVisualState()
+{
+	if (IsValid(DisplayTextBlock.Get()))
+	{
+		DisplayTextBlock->SetText(ResolveSQLUIListItemDisplayText(ListItemData));
+	}
+
+	if (IsValid(ItemIdTextBlock.Get()))
+	{
+		ItemIdTextBlock->SetText(FText::FromString(ListItemData.ItemId));
+		ItemIdTextBlock->SetVisibility(
+			ListItemData.ItemId.IsEmpty()
+				? ESlateVisibility::Collapsed
+				: ESlateVisibility::HitTestInvisible);
+	}
 }

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIListWidget.cpp
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIListWidget.cpp
@@ -1,5 +1,45 @@
 #include "Widgets/SQLUIListWidget.h"
 
+#include "Blueprint/WidgetTree.h"
+#include "Brushes/SlateColorBrush.h"
+#include "Components/Border.h"
+#include "Components/ScrollBox.h"
+#include "Components/TextBlock.h"
+#include "Components/VerticalBox.h"
+#include "Components/VerticalBoxSlot.h"
+#include "Widgets/SQLUIListItemWidget.h"
+
+namespace
+{
+FText ResolveSQLUIListEmptyText(const FText& EmptyText)
+{
+	if (EmptyText.ToString().TrimStartAndEnd().IsEmpty())
+	{
+		return NSLOCTEXT("SQLUIWidgets", "SQLUIListEmptyState", "No items");
+	}
+
+	return EmptyText;
+}
+
+void ApplySQLUIListBorderDefaults(UBorder& Border)
+{
+	Border.SetBrush(FSlateColorBrush(FLinearColor(0.018f, 0.024f, 0.034f, 0.96f)));
+	Border.SetBrushColor(FLinearColor::White);
+	Border.SetContentColorAndOpacity(FLinearColor::White);
+	Border.SetPadding(FMargin(8.0f));
+}
+
+void ApplySQLUIListEmptyTextDefaults(UTextBlock& TextBlock)
+{
+	FSlateFontInfo FontInfo = TextBlock.GetFont();
+	FontInfo.Size = 14;
+
+	TextBlock.SetFont(FontInfo);
+	TextBlock.SetColorAndOpacity(FSlateColor(FLinearColor(0.66f, 0.72f, 0.82f, 1.0f)));
+	TextBlock.SetAutoWrapText(true);
+}
+}
+
 void USQLUIListWidget::SetItems(const TArray<FSQLUIListItemData>& InItems)
 {
 	Items = InItems;
@@ -17,6 +57,161 @@ void USQLUIListWidget::ClearItems()
 	NativeOnItemsChanged();
 }
 
+void USQLUIListWidget::SetEmptyText(const FText& InEmptyText)
+{
+	EmptyText = InEmptyText;
+	RebuildListItems();
+}
+
+FText USQLUIListWidget::GetEmptyText() const
+{
+	return ResolveSQLUIListEmptyText(EmptyText);
+}
+
+void USQLUIListWidget::NativeOnInitialized()
+{
+	Super::NativeOnInitialized();
+	EnsureVisualRoot();
+	RebuildListItems();
+}
+
+void USQLUIListWidget::NativeOnSQLUIWidgetInitialized()
+{
+	Super::NativeOnSQLUIWidgetInitialized();
+	EnsureVisualRoot();
+	RebuildListItems();
+}
+
 void USQLUIListWidget::NativeOnItemsChanged()
 {
+	RebuildListItems();
+}
+
+bool USQLUIListWidget::NativeApplySQLUIWidgetProperty(
+	const FString& PropertyName,
+	const FString& PropertyValue,
+	FString& OutFailureMessage,
+	bool& bOutUnsupportedProperty)
+{
+	if (PropertyName == TEXT("EmptyText"))
+	{
+		SetEmptyText(FText::FromString(PropertyValue));
+		return true;
+	}
+
+	return Super::NativeApplySQLUIWidgetProperty(
+		PropertyName,
+		PropertyValue,
+		OutFailureMessage,
+		bOutUnsupportedProperty);
+}
+
+void USQLUIListWidget::EnsureVisualRoot()
+{
+	if (IsValid(ItemContainer.Get()) || !WidgetTree)
+	{
+		return;
+	}
+
+	if (UVerticalBox* ExistingRootVerticalBox = Cast<UVerticalBox>(WidgetTree->RootWidget))
+	{
+		ItemContainer = ExistingRootVerticalBox;
+		return;
+	}
+
+	if (WidgetTree->RootWidget)
+	{
+		return;
+	}
+
+	ListBorder = WidgetTree->ConstructWidget<UBorder>(
+		UBorder::StaticClass(),
+		TEXT("SQLUIListBorder"));
+	ListScrollBox = WidgetTree->ConstructWidget<UScrollBox>(
+		UScrollBox::StaticClass(),
+		TEXT("SQLUIListScrollBox"));
+	ItemContainer = WidgetTree->ConstructWidget<UVerticalBox>(
+		UVerticalBox::StaticClass(),
+		TEXT("SQLUIListItemContainer"));
+
+	if (!IsValid(ListBorder.Get()) || !IsValid(ListScrollBox.Get()) || !IsValid(ItemContainer.Get()))
+	{
+		return;
+	}
+
+	ApplySQLUIListBorderDefaults(*ListBorder);
+	ListScrollBox->AddChild(ItemContainer.Get());
+	ListBorder->SetContent(ListScrollBox.Get());
+	WidgetTree->RootWidget = ListBorder.Get();
+}
+
+void USQLUIListWidget::RebuildListItems()
+{
+	EnsureVisualRoot();
+
+	if (!IsValid(ItemContainer.Get()))
+	{
+		return;
+	}
+
+	ItemContainer->ClearChildren();
+	ItemWidgets.Reset();
+	EmptyTextBlock = nullptr;
+
+	if (Items.IsEmpty())
+	{
+		AddEmptyStateRow();
+		return;
+	}
+
+	ItemWidgets.Reserve(Items.Num());
+	for (const FSQLUIListItemData& ItemData : Items)
+	{
+		AddListItemRow(ItemData);
+	}
+}
+
+void USQLUIListWidget::AddEmptyStateRow()
+{
+	if (!IsValid(ItemContainer.Get()) || !WidgetTree)
+	{
+		return;
+	}
+
+	EmptyTextBlock = WidgetTree->ConstructWidget<UTextBlock>(UTextBlock::StaticClass());
+	if (!IsValid(EmptyTextBlock.Get()))
+	{
+		return;
+	}
+
+	ApplySQLUIListEmptyTextDefaults(*EmptyTextBlock);
+	EmptyTextBlock->SetText(GetEmptyText());
+
+	if (UVerticalBoxSlot* EmptyTextSlot = ItemContainer->AddChildToVerticalBox(EmptyTextBlock.Get()))
+	{
+		EmptyTextSlot->SetPadding(FMargin(2.0f, 4.0f));
+	}
+}
+
+void USQLUIListWidget::AddListItemRow(const FSQLUIListItemData& ItemData)
+{
+	if (!IsValid(ItemContainer.Get()) || !WidgetTree)
+	{
+		return;
+	}
+
+	USQLUIListItemWidget* ItemWidget = WidgetTree->ConstructWidget<USQLUIListItemWidget>(
+		USQLUIListItemWidget::StaticClass());
+	if (!IsValid(ItemWidget))
+	{
+		return;
+	}
+
+	ItemWidget->SetListItemData(ItemData);
+	ItemWidgets.Add(ItemWidget);
+
+	if (UVerticalBoxSlot* ItemSlot = ItemContainer->AddChildToVerticalBox(ItemWidget))
+	{
+		ItemSlot->SetPadding(FMargin(0.0f, 0.0f, 0.0f, 6.0f));
+	}
 }

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIListItemWidget.h
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIListItemWidget.h
@@ -6,6 +6,10 @@
 
 #include "SQLUIListItemWidget.generated.h"
 
+class UBorder;
+class UTextBlock;
+class UVerticalBox;
+
 UCLASS(BlueprintType, Blueprintable)
 class SQLUIWIDGETS_API USQLUIListItemWidget : public USQLUIBaseWidget
 {
@@ -19,6 +23,8 @@ public:
 	FSQLUIListItemData GetListItemData() const;
 
 protected:
+	virtual void NativeOnInitialized() override;
+	virtual void NativeOnSQLUIWidgetInitialized() override;
 	virtual void NativeOnListItemDataChanged();
 	virtual bool NativeApplySQLUIWidgetProperty(
 		const FString& PropertyName,
@@ -27,6 +33,21 @@ protected:
 		bool& bOutUnsupportedProperty) override;
 
 private:
+	void EnsureVisualRoot();
+	void SyncVisualState();
+
 	UPROPERTY(Transient, BlueprintReadOnly, Category = "SQLUI|List", meta = (AllowPrivateAccess = "true"))
 	FSQLUIListItemData ListItemData;
+
+	UPROPERTY(Transient)
+	TObjectPtr<UBorder> ItemBorder = nullptr;
+
+	UPROPERTY(Transient)
+	TObjectPtr<UVerticalBox> ItemTextContainer = nullptr;
+
+	UPROPERTY(Transient)
+	TObjectPtr<UTextBlock> DisplayTextBlock = nullptr;
+
+	UPROPERTY(Transient)
+	TObjectPtr<UTextBlock> ItemIdTextBlock = nullptr;
 };

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIListWidget.h
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIListWidget.h
@@ -6,6 +6,12 @@
 
 #include "SQLUIListWidget.generated.h"
 
+class UBorder;
+class UScrollBox;
+class UTextBlock;
+class UVerticalBox;
+class USQLUIListItemWidget;
+
 UCLASS(BlueprintType, Blueprintable)
 class SQLUIWIDGETS_API USQLUIListWidget : public USQLUIBaseWidget
 {
@@ -21,10 +27,46 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "SQLUI|List")
 	void ClearItems();
 
+	UFUNCTION(BlueprintCallable, Category = "SQLUI|List")
+	void SetEmptyText(const FText& InEmptyText);
+
+	UFUNCTION(BlueprintPure, Category = "SQLUI|List")
+	FText GetEmptyText() const;
+
 protected:
+	virtual void NativeOnInitialized() override;
+	virtual void NativeOnSQLUIWidgetInitialized() override;
 	virtual void NativeOnItemsChanged();
+	virtual bool NativeApplySQLUIWidgetProperty(
+		const FString& PropertyName,
+		const FString& PropertyValue,
+		FString& OutFailureMessage,
+		bool& bOutUnsupportedProperty) override;
 
 private:
+	void EnsureVisualRoot();
+	void RebuildListItems();
+	void AddEmptyStateRow();
+	void AddListItemRow(const FSQLUIListItemData& ItemData);
+
 	UPROPERTY(Transient, BlueprintReadOnly, Category = "SQLUI|List", meta = (AllowPrivateAccess = "true"))
 	TArray<FSQLUIListItemData> Items;
+
+	UPROPERTY(Transient, BlueprintReadOnly, Category = "SQLUI|List", meta = (AllowPrivateAccess = "true"))
+	FText EmptyText;
+
+	UPROPERTY(Transient)
+	TObjectPtr<UBorder> ListBorder = nullptr;
+
+	UPROPERTY(Transient)
+	TObjectPtr<UScrollBox> ListScrollBox = nullptr;
+
+	UPROPERTY(Transient)
+	TObjectPtr<UVerticalBox> ItemContainer = nullptr;
+
+	UPROPERTY(Transient)
+	TObjectPtr<UTextBlock> EmptyTextBlock = nullptr;
+
+	UPROPERTY(Transient)
+	TArray<TObjectPtr<USQLUIListItemWidget>> ItemWidgets;
 };


### PR DESCRIPTION
Summary
- Added minimal native visual implementation for SQLUI ListWidget
- Added minimal native visual implementation for SQLUI ListItemWidget
- Displays list item text using native UMG widgets
- Adds empty-state display for empty lists
- Keeps list behavior simple and source-only

Validation
- Ran git diff --check
- Built JerryRiggedEditor Win64 Development successfully
- Ran existing SQLUI smoke test successfully

Notes
- Does not edit maps or Content
- Does not add Blueprint assets
- Does not add SQLite/database behavior
- Does not touch SQLUICore or SQLUISamples
- Does not add selection, actions, metadata rendering, or full list virtualization yet