### PR TITLE
Add SQLUI samples visual list demo actor

### DIFF
--- a/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleVisualListDemoActor.cpp
+++ b/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleVisualListDemoActor.cpp
@@ -1,0 +1,126 @@
+#include "SQLUISampleVisualListDemoActor.h"
+
+#include "SQLUISamplesModule.h"
+#include "Blueprint/UserWidget.h"
+#include "Engine/World.h"
+#include "GameFramework/PlayerController.h"
+#include "Widgets/SQLUIListTypes.h"
+#include "Widgets/SQLUIListWidget.h"
+
+namespace
+{
+FSQLUIListItemData MakeSQLUISampleVisualListItem(
+	const FString& ItemId,
+	const FText& DisplayText)
+{
+	FSQLUIListItemData ItemData;
+	ItemData.ItemId = ItemId;
+	ItemData.DisplayText = DisplayText;
+	return ItemData;
+}
+
+TArray<FSQLUIListItemData> MakeSQLUISampleVisualListItems()
+{
+	TArray<FSQLUIListItemData> Items;
+	Items.Reserve(3);
+	Items.Add(MakeSQLUISampleVisualListItem(
+		TEXT("SQLUI.Sample.List.Row.001"),
+		NSLOCTEXT("SQLUISamples", "VisualListDemoFirstRow", "Sample row: Alpha assembly")));
+	Items.Add(MakeSQLUISampleVisualListItem(
+		TEXT("SQLUI.Sample.List.Row.002"),
+		NSLOCTEXT("SQLUISamples", "VisualListDemoSecondRow", "Sample row: Bravo wiring")));
+	Items.Add(MakeSQLUISampleVisualListItem(
+		TEXT("SQLUI.Sample.List.Row.003"),
+		NSLOCTEXT("SQLUISamples", "VisualListDemoThirdRow", "Sample row: Charlie verification")));
+	return Items;
+}
+}
+
+ASQLUISampleVisualListDemoActor::ASQLUISampleVisualListDemoActor()
+{
+	PrimaryActorTick.bCanEverTick = false;
+}
+
+void ASQLUISampleVisualListDemoActor::BeginPlay()
+{
+	Super::BeginPlay();
+
+	if (bRunOnBeginPlay)
+	{
+		RunVisualListDemo();
+	}
+}
+
+void ASQLUISampleVisualListDemoActor::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+	if (IsValid(AddedListWidget.Get()))
+	{
+		AddedListWidget->RemoveFromParent();
+		AddedListWidget = nullptr;
+	}
+
+	Super::EndPlay(EndPlayReason);
+}
+
+void ASQLUISampleVisualListDemoActor::RunVisualListDemo()
+{
+	if (IsValid(AddedListWidget.Get()))
+	{
+		AddedListWidget->RemoveFromParent();
+		AddedListWidget = nullptr;
+	}
+
+	UWorld* World = GetWorld();
+	APlayerController* OwningPlayer = World ? World->GetFirstPlayerController() : nullptr;
+
+	USQLUIListWidget* ListWidget = nullptr;
+	if (IsValid(OwningPlayer))
+	{
+		ListWidget = CreateWidget<USQLUIListWidget>(
+			OwningPlayer,
+			USQLUIListWidget::StaticClass());
+	}
+	else if (World)
+	{
+		ListWidget = CreateWidget<USQLUIListWidget>(
+			World,
+			USQLUIListWidget::StaticClass());
+	}
+
+	if (!IsValid(ListWidget))
+	{
+		UE_LOG(LogSQLUISamples, Error, TEXT("SQLUI sample visual list demo failed: could not create list widget."));
+		return;
+	}
+
+	const TArray<FSQLUIListItemData> Items = MakeSQLUISampleVisualListItems();
+	ListWidget->SetItems(Items);
+	AddedListWidget = ListWidget;
+
+	bool bAddedToViewport = false;
+	if (bAddToViewport)
+	{
+		ListWidget->AddToViewport(ViewportZOrder);
+		ListWidget->SetPositionInViewport(ViewportPosition, true);
+		if (ViewportSize.X > 0.0f && ViewportSize.Y > 0.0f)
+		{
+			ListWidget->SetDesiredSizeInViewport(ViewportSize);
+		}
+
+		bAddedToViewport = true;
+	}
+
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample visual list demo succeeded. Row count: %d"),
+		Items.Num());
+
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample visual list demo viewport add status: %s"),
+		bAddToViewport
+			? (bAddedToViewport ? TEXT("added") : TEXT("failed"))
+			: TEXT("skipped"));
+}

--- a/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISampleVisualListDemoActor.h
+++ b/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISampleVisualListDemoActor.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+
+#include "SQLUISampleVisualListDemoActor.generated.h"
+
+class USQLUIListWidget;
+
+UCLASS(BlueprintType)
+class SQLUISAMPLES_API ASQLUISampleVisualListDemoActor : public AActor
+{
+	GENERATED_BODY()
+
+public:
+	ASQLUISampleVisualListDemoActor();
+
+	UFUNCTION(BlueprintCallable, Category = "SQLUI|Samples")
+	void RunVisualListDemo();
+
+protected:
+	virtual void BeginPlay() override;
+	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+public:
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bRunOnBeginPlay = true;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bAddToViewport = true;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FVector2D ViewportPosition = FVector2D(24.0f, 96.0f);
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FVector2D ViewportSize = FVector2D(420.0f, 220.0f);
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	int32 ViewportZOrder = 0;
+
+private:
+	UPROPERTY(Transient)
+	TObjectPtr<USQLUIListWidget> AddedListWidget = nullptr;
+};


### PR DESCRIPTION
Summary
- Added a SQLUISamples visual ListWidget demo actor
- Creates a USQLUIListWidget in Play mode
- Populates it with sample list item rows
- Adds the list widget to the viewport when requested
- Removes the list widget on EndPlay

Validation
- Ran git diff --check
- Built JerryRiggedEditor Win64 Development successfully

Notes
- Does not edit maps or Content
- Does not add Blueprint assets
- Does not add SQLite/database behavior
- Does not touch SQLUICore or SQLUIWidgets
- Intended for manual Play-in-Editor visual verification