### PR TITLE
Codex/sqlui vertical container widget

### DIFF
--- a/Plugins/SQLUI/Source/SQLUIWidgets/Private/Assembly/SQLUIWidgetTreeAssembler.cpp
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Private/Assembly/SQLUIWidgetTreeAssembler.cpp
@@ -446,6 +446,18 @@ FSQLUIAssembledWidgetNode MakeSQLUIAssembledWidgetNode(
 			{
 				AddSQLUIWidgetTreeAssemblyWarning(Result, UnsupportedContainerMessage);
 			}
+
+			continue;
+		}
+
+		if (!AssembledNode.Widget->AddSQLUIChildWidget(ChildWidget))
+		{
+			AddSQLUIWidgetTreeAssemblyError(
+				Result,
+				FString::Printf(
+					TEXT("SQLUI widget tree assembly parent '%s' accepted child '%s' but could not attach it."),
+					*LayoutNode.WidgetId,
+					*ChildWidgetId));
 		}
 	}
 

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Private/WidgetCatalog/SQLUIWidgetCatalogRegistrar.cpp
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Private/WidgetCatalog/SQLUIWidgetCatalogRegistrar.cpp
@@ -3,6 +3,7 @@
 #include "Widgets/SQLUIFilterBox.h"
 #include "Widgets/SQLUIListItemWidget.h"
 #include "Widgets/SQLUIListWidget.h"
+#include "Widgets/SQLUIVerticalBoxWidget.h"
 
 namespace
 {
@@ -20,6 +21,11 @@ TArray<FString> MakeSQLUIVariableBindingKeys()
 		TEXT("VariableStore")
 	};
 }
+}
+
+FSQLUIWidgetTypeKey FSQLUIWidgetTypeKeys::VerticalBox()
+{
+	return MakeSQLUIWidgetTypeKey(TEXT("SQLUI.VerticalBox"));
 }
 
 FSQLUIWidgetTypeKey FSQLUIWidgetTypeKeys::FilterBox()
@@ -45,10 +51,32 @@ bool USQLUIWidgetCatalogRegistrar::RegisterDefaultSQLUIWidgets(USQLUIWidgetCatal
 	}
 
 	bool bRegisteredAll = true;
+	bRegisteredAll &= RegisterVerticalBox(WidgetCatalog);
 	bRegisteredAll &= RegisterFilterBox(WidgetCatalog);
 	bRegisteredAll &= RegisterListWidget(WidgetCatalog);
 	bRegisteredAll &= RegisterListItemWidget(WidgetCatalog);
 	return bRegisteredAll;
+}
+
+bool USQLUIWidgetCatalogRegistrar::RegisterVerticalBox(USQLUIWidgetCatalog* WidgetCatalog)
+{
+	if (!WidgetCatalog)
+	{
+		return false;
+	}
+
+	FSQLUIWidgetCatalogEntry Entry;
+	Entry.WidgetTypeKey = FSQLUIWidgetTypeKeys::VerticalBox();
+	Entry.DisplayName = TEXT("Vertical Box");
+	Entry.Description = TEXT("SQLUI vertical container widget metadata.");
+	Entry.WidgetClassPath = USQLUIVerticalBoxWidget::StaticClass()->GetPathName();
+	Entry.SupportedPropertyKeys = {
+		TEXT("IsEnabled")
+	};
+	Entry.SupportedBindingKeys = MakeSQLUIVariableBindingKeys();
+	Entry.SupportedActionKeys = {};
+
+	return WidgetCatalog->RegisterEntry(Entry);
 }
 
 bool USQLUIWidgetCatalogRegistrar::RegisterFilterBox(USQLUIWidgetCatalog* WidgetCatalog)

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIBaseWidget.cpp
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIBaseWidget.cpp
@@ -83,6 +83,11 @@ bool USQLUIBaseWidget::CanAcceptSQLUIChildWidget(
 	return false;
 }
 
+bool USQLUIBaseWidget::AddSQLUIChildWidget(USQLUIBaseWidget* ChildWidget)
+{
+	return false;
+}
+
 void USQLUIBaseWidget::NativeOnSQLUIWidgetInitialized()
 {
 }

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIVerticalBoxWidget.cpp
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIVerticalBoxWidget.cpp
@@ -1,0 +1,111 @@
+#include "Widgets/SQLUIVerticalBoxWidget.h"
+
+#include "Blueprint/WidgetTree.h"
+#include "Components/VerticalBox.h"
+#include "Components/VerticalBoxSlot.h"
+
+namespace
+{
+void ApplySQLUIVerticalBoxSlotDefaults(UVerticalBoxSlot& Slot)
+{
+	Slot.SetHorizontalAlignment(HAlign_Fill);
+	Slot.SetVerticalAlignment(VAlign_Top);
+	Slot.SetPadding(FMargin(0.0f, 0.0f, 0.0f, 8.0f));
+}
+}
+
+bool USQLUIVerticalBoxWidget::CanAcceptSQLUIChildWidget(
+	const USQLUIBaseWidget* ChildWidget,
+	const FSQLUILayoutNode& ChildLayoutNode) const
+{
+	return IsValid(ChildWidget) && ChildWidget != this;
+}
+
+bool USQLUIVerticalBoxWidget::AddSQLUIChildWidget(USQLUIBaseWidget* ChildWidget)
+{
+	if (!CanAcceptSQLUIChildWidget(
+		ChildWidget,
+		IsValid(ChildWidget) ? ChildWidget->GetSQLUILayoutNode() : FSQLUILayoutNode()))
+	{
+		return false;
+	}
+
+	EnsureVerticalBoxRoot();
+	if (!IsValid(ChildContainer.Get()))
+	{
+		return false;
+	}
+
+	if (ChildWidget->GetParent() == ChildContainer.Get())
+	{
+		ChildWidgets.AddUnique(ChildWidget);
+		return true;
+	}
+
+	if (ChildWidget->GetParent())
+	{
+		return false;
+	}
+
+	UVerticalBoxSlot* ChildSlot = ChildContainer->AddChildToVerticalBox(ChildWidget);
+	if (!ChildSlot)
+	{
+		return false;
+	}
+
+	ApplySQLUIVerticalBoxSlotDefaults(*ChildSlot);
+	ChildWidgets.AddUnique(ChildWidget);
+	return true;
+}
+
+void USQLUIVerticalBoxWidget::ClearSQLUIChildWidgets()
+{
+	EnsureVerticalBoxRoot();
+
+	if (IsValid(ChildContainer.Get()))
+	{
+		ChildContainer->ClearChildren();
+	}
+
+	ChildWidgets.Reset();
+}
+
+void USQLUIVerticalBoxWidget::NativeOnInitialized()
+{
+	Super::NativeOnInitialized();
+	EnsureVerticalBoxRoot();
+}
+
+void USQLUIVerticalBoxWidget::NativeOnSQLUIWidgetInitialized()
+{
+	Super::NativeOnSQLUIWidgetInitialized();
+	EnsureVerticalBoxRoot();
+}
+
+void USQLUIVerticalBoxWidget::EnsureVerticalBoxRoot()
+{
+	if (IsValid(ChildContainer.Get()) || !WidgetTree)
+	{
+		return;
+	}
+
+	if (UVerticalBox* ExistingRootVerticalBox = Cast<UVerticalBox>(WidgetTree->RootWidget))
+	{
+		ChildContainer = ExistingRootVerticalBox;
+		return;
+	}
+
+	if (WidgetTree->RootWidget)
+	{
+		return;
+	}
+
+	ChildContainer = WidgetTree->ConstructWidget<UVerticalBox>(
+		UVerticalBox::StaticClass(),
+		TEXT("SQLUIVerticalBox"));
+
+	if (IsValid(ChildContainer.Get()))
+	{
+		WidgetTree->RootWidget = ChildContainer.Get();
+	}
+}

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Public/WidgetCatalog/SQLUIWidgetCatalogRegistrar.h
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Public/WidgetCatalog/SQLUIWidgetCatalogRegistrar.h
@@ -8,6 +8,7 @@
 
 struct SQLUIWIDGETS_API FSQLUIWidgetTypeKeys
 {
+	static FSQLUIWidgetTypeKey VerticalBox();
 	static FSQLUIWidgetTypeKey FilterBox();
 	static FSQLUIWidgetTypeKey ListWidget();
 	static FSQLUIWidgetTypeKey ListItemWidget();
@@ -20,6 +21,7 @@ class SQLUIWIDGETS_API USQLUIWidgetCatalogRegistrar : public UObject
 
 public:
 	static bool RegisterDefaultSQLUIWidgets(USQLUIWidgetCatalog* WidgetCatalog);
+	static bool RegisterVerticalBox(USQLUIWidgetCatalog* WidgetCatalog);
 	static bool RegisterFilterBox(USQLUIWidgetCatalog* WidgetCatalog);
 	static bool RegisterListWidget(USQLUIWidgetCatalog* WidgetCatalog);
 	static bool RegisterListItemWidget(USQLUIWidgetCatalog* WidgetCatalog);

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIBaseWidget.h
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIBaseWidget.h
@@ -53,6 +53,9 @@ public:
 		const USQLUIBaseWidget* ChildWidget,
 		const FSQLUILayoutNode& ChildLayoutNode) const;
 
+	UFUNCTION(BlueprintCallable, Category = "SQLUI|Widget")
+	virtual bool AddSQLUIChildWidget(USQLUIBaseWidget* ChildWidget);
+
 protected:
 	virtual void NativeOnSQLUIWidgetInitialized();
 

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIVerticalBoxWidget.h
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIVerticalBoxWidget.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SQLUIBaseWidget.h"
+
+#include "SQLUIVerticalBoxWidget.generated.h"
+
+class UVerticalBox;
+
+UCLASS(BlueprintType, Blueprintable)
+class SQLUIWIDGETS_API USQLUIVerticalBoxWidget : public USQLUIBaseWidget
+{
+	GENERATED_BODY()
+
+public:
+	virtual bool CanAcceptSQLUIChildWidget(
+		const USQLUIBaseWidget* ChildWidget,
+		const FSQLUILayoutNode& ChildLayoutNode) const override;
+
+	virtual bool AddSQLUIChildWidget(USQLUIBaseWidget* ChildWidget) override;
+
+	UFUNCTION(BlueprintCallable, Category = "SQLUI|Vertical Box")
+	void ClearSQLUIChildWidgets();
+
+protected:
+	virtual void NativeOnInitialized() override;
+	virtual void NativeOnSQLUIWidgetInitialized() override;
+
+private:
+	void EnsureVerticalBoxRoot();
+
+	UPROPERTY(Transient)
+	TObjectPtr<UVerticalBox> ChildContainer = nullptr;
+
+	UPROPERTY(Transient)
+	TArray<TObjectPtr<USQLUIBaseWidget>> ChildWidgets;
+};


### PR DESCRIPTION
Summary
- Added a minimal native SQLUI VerticalBox widget
- Allows SQLUI child widgets to be arranged vertically
- Added child add/clear behavior for accepted SQLUI children
- Registered SQLUI.VerticalBox in the widget catalog
- Added a narrow child-attachment hook for supported container widgets

Validation
- Ran git diff --check
- Built JerryRiggedEditor Win64 Development successfully
- Ran existing SQLUI smoke test successfully

Notes
- Does not edit maps or Content
- Does not add Blueprint assets
- Does not add SQLite/database behavior
- Does not touch SQLUICore or SQLUISamples
- Does not implement a full renderer yet