### PR TITLE
Add layout-driven SQLUI filter list sample actor

### DIFF
--- a/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleLayoutDrivenFilterListDemoActor.cpp
+++ b/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleLayoutDrivenFilterListDemoActor.cpp
@@ -1,0 +1,277 @@
+#include "SQLUISampleLayoutDrivenFilterListDemoActor.h"
+
+#include "SQLUISamplesModule.h"
+#include "Engine/World.h"
+#include "GameFramework/PlayerController.h"
+#include "Runtime/SQLUIRuntimeContext.h"
+#include "WidgetCatalog/SQLUIWidgetCatalog.h"
+#include "WidgetCatalog/SQLUIWidgetCatalogRegistrar.h"
+#include "Widgets/SQLUIBaseWidget.h"
+
+namespace
+{
+const TCHAR* SQLUISampleLayoutDrivenFilterListDemoStepStatusToString(
+	const ESQLUIRuntimeWidgetPipelineStepStatus Status)
+{
+	switch (Status)
+	{
+	case ESQLUIRuntimeWidgetPipelineStepStatus::NotRun:
+		return TEXT("NotRun");
+	case ESQLUIRuntimeWidgetPipelineStepStatus::Skipped:
+		return TEXT("Skipped");
+	case ESQLUIRuntimeWidgetPipelineStepStatus::Succeeded:
+		return TEXT("Succeeded");
+	case ESQLUIRuntimeWidgetPipelineStepStatus::Failed:
+		return TEXT("Failed");
+	default:
+		return TEXT("Unknown");
+	}
+}
+
+const TCHAR* SQLUISampleLayoutDrivenFilterListDemoBoolToString(const bool bValue)
+{
+	return bValue ? TEXT("true") : TEXT("false");
+}
+
+void LogSQLUISampleLayoutDrivenFilterListDemoErrors(const TArray<FString>& Messages)
+{
+	for (const FString& Message : Messages)
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample layout-driven filter/list demo error: %s"),
+			*Message);
+	}
+}
+
+void LogSQLUISampleLayoutDrivenFilterListDemoWarnings(const TArray<FString>& Messages)
+{
+	for (const FString& Message : Messages)
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Warning,
+			TEXT("SQLUI sample layout-driven filter/list demo warning: %s"),
+			*Message);
+	}
+}
+
+void LogSQLUISampleLayoutDrivenFilterListDemoStepResults(
+	const TArray<FSQLUIRuntimeWidgetPipelineStepResult>& StepResults)
+{
+	for (const FSQLUIRuntimeWidgetPipelineStepResult& StepResult : StepResults)
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Log,
+			TEXT("SQLUI sample layout-driven filter/list demo step '%s': %s"),
+			*StepResult.StepName,
+			SQLUISampleLayoutDrivenFilterListDemoStepStatusToString(StepResult.Status));
+	}
+}
+
+FSQLUILayoutDocument MakeSQLUISampleLayoutDrivenFilterListDocument()
+{
+	const FString RootWidgetId = TEXT("SQLUI.Sample.LayoutDrivenFilterList.Root");
+	const FString FilterBoxWidgetId = TEXT("SQLUI.Sample.LayoutDrivenFilterList.FilterBox");
+	const FString ListWidgetId = TEXT("SQLUI.Sample.LayoutDrivenFilterList.ListWidget");
+
+	FSQLUILayoutDocument Document;
+	Document.Version.SchemaVersion = 1;
+	Document.Version.Revision = 1;
+	Document.Version.Label = TEXT("SQLUI Sample Layout-Driven Filter/List Demo");
+	Document.Metadata.LayoutId = TEXT("sqlui.sample.layout-driven-filter-list-demo");
+	Document.Metadata.DisplayName = TEXT("SQLUI Sample Layout-Driven Filter/List Demo");
+	Document.Metadata.Description = TEXT("Minimal SQLUISamples layout-driven FilterBox and ListWidget visual demo.");
+	Document.Metadata.CreatedBy = TEXT("SQLUISamples");
+	Document.RootWidgetId = RootWidgetId;
+
+	FSQLUILayoutNode RootNode;
+	RootNode.WidgetId = RootWidgetId;
+	RootNode.WidgetTypeKey = FSQLUIWidgetTypeKeys::VerticalBox().Value;
+	RootNode.ChildWidgetIds.Add(FilterBoxWidgetId);
+	RootNode.ChildWidgetIds.Add(ListWidgetId);
+	RootNode.Properties.Add(TEXT("IsEnabled"), TEXT("true"));
+
+	FSQLUILayoutNode FilterBoxNode;
+	FilterBoxNode.WidgetId = FilterBoxWidgetId;
+	FilterBoxNode.ParentWidgetId = RootWidgetId;
+	FilterBoxNode.WidgetTypeKey = FSQLUIWidgetTypeKeys::FilterBox().Value;
+	FilterBoxNode.Properties.Add(TEXT("PlaceholderText"), TEXT("Filter layout-driven sample rows"));
+	FilterBoxNode.Properties.Add(TEXT("IsEnabled"), TEXT("true"));
+
+	FSQLUILayoutNode ListWidgetNode;
+	ListWidgetNode.WidgetId = ListWidgetId;
+	ListWidgetNode.ParentWidgetId = RootWidgetId;
+	ListWidgetNode.WidgetTypeKey = FSQLUIWidgetTypeKeys::ListWidget().Value;
+	ListWidgetNode.Properties.Add(TEXT("EmptyText"), TEXT("No layout-driven sample rows yet"));
+	ListWidgetNode.Properties.Add(TEXT("IsEnabled"), TEXT("true"));
+
+	Document.Nodes.Add(RootNode);
+	Document.Nodes.Add(FilterBoxNode);
+	Document.Nodes.Add(ListWidgetNode);
+
+	return Document;
+}
+
+void LogSQLUISampleLayoutDrivenFilterListDemoResult(
+	const FSQLUIRuntimeWidgetPipelineResult& PipelineResult)
+{
+	if (PipelineResult.bSucceeded)
+	{
+		UE_LOG(LogSQLUISamples, Log, TEXT("SQLUI sample layout-driven filter/list demo succeeded."));
+	}
+	else
+	{
+		UE_LOG(LogSQLUISamples, Error, TEXT("SQLUI sample layout-driven filter/list demo failed."));
+	}
+
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample layout-driven filter/list demo root widget valid: %s"),
+		SQLUISampleLayoutDrivenFilterListDemoBoolToString(IsValid(PipelineResult.RootWidget.Get())));
+
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample layout-driven filter/list demo created widget count: %d"),
+		PipelineResult.CreatedWidgets.Num());
+
+	LogSQLUISampleLayoutDrivenFilterListDemoStepResults(PipelineResult.StepResults);
+	LogSQLUISampleLayoutDrivenFilterListDemoErrors(PipelineResult.Errors);
+	LogSQLUISampleLayoutDrivenFilterListDemoWarnings(PipelineResult.Warnings);
+}
+}
+
+ASQLUISampleLayoutDrivenFilterListDemoActor::ASQLUISampleLayoutDrivenFilterListDemoActor()
+{
+	PrimaryActorTick.bCanEverTick = false;
+}
+
+void ASQLUISampleLayoutDrivenFilterListDemoActor::BeginPlay()
+{
+	Super::BeginPlay();
+
+	if (bRunOnBeginPlay)
+	{
+		RunLayoutDrivenFilterListDemo();
+	}
+}
+
+void ASQLUISampleLayoutDrivenFilterListDemoActor::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+	RemoveAddedRootWidget();
+
+	Super::EndPlay(EndPlayReason);
+}
+
+void ASQLUISampleLayoutDrivenFilterListDemoActor::RunLayoutDrivenFilterListDemo()
+{
+	RemoveAddedRootWidget();
+	LastPipelineResult = FSQLUIRuntimeWidgetPipelineResult();
+
+	USQLUIWidgetCatalog* WidgetCatalog = NewObject<USQLUIWidgetCatalog>(this);
+	if (!IsValid(WidgetCatalog))
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample layout-driven filter/list demo failed: could not create widget catalog."));
+		LogSQLUISampleLayoutDrivenFilterListDemoResult(LastPipelineResult);
+		return;
+	}
+
+	if (!USQLUIWidgetCatalogRegistrar::RegisterDefaultSQLUIWidgets(WidgetCatalog))
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample layout-driven filter/list demo failed: could not register default widget catalog entries."));
+		LogSQLUISampleLayoutDrivenFilterListDemoResult(LastPipelineResult);
+		return;
+	}
+
+	USQLUIRuntimeContext* RuntimeContext = NewObject<USQLUIRuntimeContext>(this);
+	if (!IsValid(RuntimeContext))
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample layout-driven filter/list demo failed: could not create runtime context."));
+		LogSQLUISampleLayoutDrivenFilterListDemoResult(LastPipelineResult);
+		return;
+	}
+
+	FSQLUIRuntimeContextSettings RuntimeContextSettings;
+	RuntimeContextSettings.WidgetCatalog = WidgetCatalog;
+	RuntimeContext->Initialize(RuntimeContextSettings);
+
+	if (!RuntimeContext->IsInitialized())
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample layout-driven filter/list demo failed: runtime context did not initialize."));
+		LogSQLUISampleLayoutDrivenFilterListDemoResult(LastPipelineResult);
+		return;
+	}
+
+	USQLUIRuntimeWidgetPipeline* Pipeline = NewObject<USQLUIRuntimeWidgetPipeline>(this);
+	if (!IsValid(Pipeline))
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample layout-driven filter/list demo failed: could not create runtime widget pipeline."));
+		LogSQLUISampleLayoutDrivenFilterListDemoResult(LastPipelineResult);
+		return;
+	}
+
+	UWorld* World = GetWorld();
+	APlayerController* OwningPlayer = World ? World->GetFirstPlayerController() : nullptr;
+
+	FSQLUIRuntimeWidgetPipelineRequest PipelineRequest;
+	PipelineRequest.Document = MakeSQLUISampleLayoutDrivenFilterListDocument();
+	PipelineRequest.RuntimeContext = RuntimeContext;
+	PipelineRequest.WidgetCatalogOverride = WidgetCatalog;
+	PipelineRequest.WorldContextObject = this;
+	PipelineRequest.OwningPlayer = OwningPlayer;
+
+	LastPipelineResult = Pipeline->RunPipeline(PipelineRequest);
+
+	bool bAddedToViewport = false;
+	if (bAddToViewport && IsValid(LastPipelineResult.RootWidget.Get()))
+	{
+		LastPipelineResult.RootWidget->AddToViewport(ViewportZOrder);
+		LastPipelineResult.RootWidget->SetPositionInViewport(ViewportPosition, true);
+		if (ViewportSize.X > 0.0f && ViewportSize.Y > 0.0f)
+		{
+			LastPipelineResult.RootWidget->SetDesiredSizeInViewport(ViewportSize);
+		}
+
+		AddedRootWidget = LastPipelineResult.RootWidget;
+		bAddedToViewport = true;
+	}
+
+	LogSQLUISampleLayoutDrivenFilterListDemoResult(LastPipelineResult);
+
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample layout-driven filter/list demo viewport add status: %s"),
+		bAddToViewport
+			? (bAddedToViewport ? TEXT("added") : TEXT("failed"))
+			: TEXT("skipped"));
+}
+
+void ASQLUISampleLayoutDrivenFilterListDemoActor::RemoveAddedRootWidget()
+{
+	if (IsValid(AddedRootWidget.Get()))
+	{
+		AddedRootWidget->RemoveFromParent();
+	}
+
+	AddedRootWidget = nullptr;
+}

--- a/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISampleLayoutDrivenFilterListDemoActor.h
+++ b/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISampleLayoutDrivenFilterListDemoActor.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "Pipeline/SQLUIRuntimeWidgetPipeline.h"
+
+#include "SQLUISampleLayoutDrivenFilterListDemoActor.generated.h"
+
+class USQLUIBaseWidget;
+
+UCLASS(BlueprintType)
+class SQLUISAMPLES_API ASQLUISampleLayoutDrivenFilterListDemoActor : public AActor
+{
+	GENERATED_BODY()
+
+public:
+	ASQLUISampleLayoutDrivenFilterListDemoActor();
+
+	UFUNCTION(BlueprintCallable, Category = "SQLUI|Samples")
+	void RunLayoutDrivenFilterListDemo();
+
+protected:
+	virtual void BeginPlay() override;
+	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+public:
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bRunOnBeginPlay = true;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bAddToViewport = true;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FVector2D ViewportPosition = FVector2D(24.0f, 24.0f);
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FVector2D ViewportSize = FVector2D(420.0f, 320.0f);
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	int32 ViewportZOrder = 0;
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Transient, Category = "SQLUI|Samples")
+	FSQLUIRuntimeWidgetPipelineResult LastPipelineResult;
+
+private:
+	void RemoveAddedRootWidget();
+
+	UPROPERTY(Transient)
+	TObjectPtr<USQLUIBaseWidget> AddedRootWidget = nullptr;
+};


### PR DESCRIPTION
Summary
- Added a SQLUISamples layout-driven visual FilterBox/ListWidget demo actor
- Builds an in-memory SQLUI layout document with a SQLUI.VerticalBox root
- Adds SQLUI.FilterBox and SQLUI.ListWidget child nodes through layout data
- Runs the existing SQLUI runtime widget pipeline
- Adds the generated root widget to the viewport when requested
- Removes the root widget on EndPlay

Validation
- Ran git diff --check
- Built JerryRiggedEditor Win64 Development successfully
- Manually tested Play-in-Editor layout-driven visual demo

Notes
- Does not edit maps or Content
- Does not add Blueprint assets
- Does not add SQLite/database behavior
- Does not touch SQLUICore or SQLUIWidgets
- Proves visible UI can be generated from layout data