### PR TITLE
Add layout-driven SQLUI list widget items

### DIFF
--- a/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleLayoutDrivenFilterListDemoActor.cpp
+++ b/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleLayoutDrivenFilterListDemoActor.cpp
@@ -106,6 +106,7 @@ FSQLUILayoutDocument MakeSQLUISampleLayoutDrivenFilterListDocument()
 	ListWidgetNode.ParentWidgetId = RootWidgetId;
 	ListWidgetNode.WidgetTypeKey = FSQLUIWidgetTypeKeys::ListWidget().Value;
 	ListWidgetNode.Properties.Add(TEXT("EmptyText"), TEXT("No layout-driven sample rows yet"));
+	ListWidgetNode.Properties.Add(TEXT("Items"), TEXT("row-1|First sample row;row-2|Second sample row;row-3|Third sample row"));
 	ListWidgetNode.Properties.Add(TEXT("IsEnabled"), TEXT("true"));
 
 	Document.Nodes.Add(RootNode);

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIListWidget.cpp
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIListWidget.cpp
@@ -21,6 +21,62 @@ FText ResolveSQLUIListEmptyText(const FText& EmptyText)
 	return EmptyText;
 }
 
+bool TryParseSQLUIListItemsProperty(
+	const FString& PropertyValue,
+	TArray<FSQLUIListItemData>& OutItems,
+	FString& OutFailureMessage)
+{
+	OutItems.Reset();
+	OutFailureMessage.Reset();
+
+	if (PropertyValue.TrimStartAndEnd().IsEmpty())
+	{
+		return true;
+	}
+
+	TArray<FString> RowValues;
+	PropertyValue.ParseIntoArray(RowValues, TEXT(";"), false);
+
+	for (int32 RowIndex = 0; RowIndex < RowValues.Num(); ++RowIndex)
+	{
+		const FString RowValue = RowValues[RowIndex].TrimStartAndEnd();
+		if (RowValue.IsEmpty())
+		{
+			OutFailureMessage = FString::Printf(
+				TEXT("SQLUI list widget property 'Items' contains an empty row at index %d."),
+				RowIndex);
+			return false;
+		}
+
+		FString ItemId;
+		FString DisplayText;
+		if (!RowValue.Split(TEXT("|"), &ItemId, &DisplayText, ESearchCase::CaseSensitive, ESearchDir::FromStart))
+		{
+			OutFailureMessage = FString::Printf(
+				TEXT("SQLUI list widget property 'Items' row %d must use the format 'ItemId|Display text'."),
+				RowIndex);
+			return false;
+		}
+
+		ItemId = ItemId.TrimStartAndEnd();
+		DisplayText = DisplayText.TrimStartAndEnd();
+		if (DisplayText.IsEmpty())
+		{
+			OutFailureMessage = FString::Printf(
+				TEXT("SQLUI list widget property 'Items' row %d must include non-empty display text."),
+				RowIndex);
+			return false;
+		}
+
+		FSQLUIListItemData ItemData;
+		ItemData.ItemId = ItemId;
+		ItemData.DisplayText = FText::FromString(DisplayText);
+		OutItems.Add(ItemData);
+	}
+
+	return true;
+}
+
 void ApplySQLUIListBorderDefaults(UBorder& Border)
 {
 	Border.SetBrush(FSlateColorBrush(FLinearColor(0.018f, 0.024f, 0.034f, 0.96f)));
@@ -93,6 +149,26 @@ bool USQLUIListWidget::NativeApplySQLUIWidgetProperty(
 	FString& OutFailureMessage,
 	bool& bOutUnsupportedProperty)
 {
+	if (PropertyName == TEXT("Items"))
+	{
+		TArray<FSQLUIListItemData> ParsedItems;
+		if (!TryParseSQLUIListItemsProperty(PropertyValue, ParsedItems, OutFailureMessage))
+		{
+			return false;
+		}
+
+		if (ParsedItems.IsEmpty())
+		{
+			ClearItems();
+		}
+		else
+		{
+			SetItems(ParsedItems);
+		}
+
+		return true;
+	}
+
 	if (PropertyName == TEXT("EmptyText"))
 	{
 		SetEmptyText(FText::FromString(PropertyValue));


### PR DESCRIPTION
Summary
- Added minimal Items property handling for SQLUI ListWidget
- Parses simple delimiter-based list rows into FSQLUIListItemData
- Updates the layout-driven FilterBox/ListWidget sample actor with sample row data
- Shows list rows through layout data instead of only empty-state text

Validation
- Ran git diff --check
- Built JerryRiggedEditor Win64 Development successfully
- Manually tested Play-in-Editor layout-driven list rows

Notes
- Does not edit maps or Content
- Does not add Blueprint assets
- Does not add SQLite/database behavior
- Does not add JSON parsing or a full data-source system
- Does not connect FilterBox filtering yet