### PR TITLE
Add FilterBox-driven filtering to SQLUI layout demo

### DIFF
--- a/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleLayoutDrivenFilterListDemoActor.cpp
+++ b/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleLayoutDrivenFilterListDemoActor.cpp
@@ -7,9 +7,18 @@
 #include "WidgetCatalog/SQLUIWidgetCatalog.h"
 #include "WidgetCatalog/SQLUIWidgetCatalogRegistrar.h"
 #include "Widgets/SQLUIBaseWidget.h"
+#include "Widgets/SQLUIFilterBox.h"
+#include "Widgets/SQLUIListWidget.h"
 
 namespace
 {
+const TCHAR* SQLUISampleLayoutDrivenFilterListRootWidgetId =
+	TEXT("SQLUI.Sample.LayoutDrivenFilterList.Root");
+const TCHAR* SQLUISampleLayoutDrivenFilterListFilterBoxWidgetId =
+	TEXT("SQLUI.Sample.LayoutDrivenFilterList.FilterBox");
+const TCHAR* SQLUISampleLayoutDrivenFilterListListWidgetId =
+	TEXT("SQLUI.Sample.LayoutDrivenFilterList.ListWidget");
+
 const TCHAR* SQLUISampleLayoutDrivenFilterListDemoStepStatusToString(
 	const ESQLUIRuntimeWidgetPipelineStepStatus Status)
 {
@@ -73,9 +82,9 @@ void LogSQLUISampleLayoutDrivenFilterListDemoStepResults(
 
 FSQLUILayoutDocument MakeSQLUISampleLayoutDrivenFilterListDocument()
 {
-	const FString RootWidgetId = TEXT("SQLUI.Sample.LayoutDrivenFilterList.Root");
-	const FString FilterBoxWidgetId = TEXT("SQLUI.Sample.LayoutDrivenFilterList.FilterBox");
-	const FString ListWidgetId = TEXT("SQLUI.Sample.LayoutDrivenFilterList.ListWidget");
+	const FString RootWidgetId = SQLUISampleLayoutDrivenFilterListRootWidgetId;
+	const FString FilterBoxWidgetId = SQLUISampleLayoutDrivenFilterListFilterBoxWidgetId;
+	const FString ListWidgetId = SQLUISampleLayoutDrivenFilterListListWidgetId;
 
 	FSQLUILayoutDocument Document;
 	Document.Version.SchemaVersion = 1;
@@ -242,6 +251,18 @@ void ASQLUISampleLayoutDrivenFilterListDemoActor::RunLayoutDrivenFilterListDemo(
 
 	LastPipelineResult = Pipeline->RunPipeline(PipelineRequest);
 
+	if (LastPipelineResult.bSucceeded)
+	{
+		ConnectLayoutDrivenFilterListWidgets();
+	}
+	else
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Warning,
+			TEXT("SQLUI sample layout-driven filter/list demo skipped filter connection because the runtime pipeline failed."));
+	}
+
 	bool bAddedToViewport = false;
 	if (bAddToViewport && IsValid(LastPipelineResult.RootWidget.Get()))
 	{
@@ -267,8 +288,73 @@ void ASQLUISampleLayoutDrivenFilterListDemoActor::RunLayoutDrivenFilterListDemo(
 			: TEXT("skipped"));
 }
 
+void ASQLUISampleLayoutDrivenFilterListDemoActor::ConnectLayoutDrivenFilterListWidgets()
+{
+	DisconnectLayoutDrivenFilterListWidgets();
+
+	USQLUIBaseWidget* const* FilterBoxBaseWidget =
+		LastPipelineResult.CreatedWidgetMap.Find(FString(SQLUISampleLayoutDrivenFilterListFilterBoxWidgetId));
+	USQLUIBaseWidget* const* ListBaseWidget =
+		LastPipelineResult.CreatedWidgetMap.Find(FString(SQLUISampleLayoutDrivenFilterListListWidgetId));
+
+	USQLUIFilterBox* FilterBox = FilterBoxBaseWidget
+		? Cast<USQLUIFilterBox>(*FilterBoxBaseWidget)
+		: nullptr;
+	USQLUIListWidget* ListWidget = ListBaseWidget
+		? Cast<USQLUIListWidget>(*ListBaseWidget)
+		: nullptr;
+
+	if (!IsValid(FilterBox) || !IsValid(ListWidget))
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Warning,
+			TEXT("SQLUI sample layout-driven filter/list demo could not connect filter to list. FilterBox valid: %s. ListWidget valid: %s."),
+			SQLUISampleLayoutDrivenFilterListDemoBoolToString(IsValid(FilterBox)),
+			SQLUISampleLayoutDrivenFilterListDemoBoolToString(IsValid(ListWidget)));
+		return;
+	}
+
+	ConnectedFilterBoxWidget = FilterBox;
+	ConnectedListWidget = ListWidget;
+	FilterTextChangedDelegateHandle = ConnectedFilterBoxWidget->OnFilterTextChanged.AddUObject(
+		this,
+		&ASQLUISampleLayoutDrivenFilterListDemoActor::HandleLayoutDrivenFilterTextChanged);
+	ConnectedListWidget->SetFilterText(ConnectedFilterBoxWidget->GetFilterText());
+
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample layout-driven filter/list demo connected FilterBox '%s' to ListWidget '%s'."),
+		SQLUISampleLayoutDrivenFilterListFilterBoxWidgetId,
+		SQLUISampleLayoutDrivenFilterListListWidgetId);
+}
+
+void ASQLUISampleLayoutDrivenFilterListDemoActor::DisconnectLayoutDrivenFilterListWidgets()
+{
+	if (IsValid(ConnectedFilterBoxWidget.Get()) && FilterTextChangedDelegateHandle.IsValid())
+	{
+		ConnectedFilterBoxWidget->OnFilterTextChanged.Remove(FilterTextChangedDelegateHandle);
+	}
+
+	FilterTextChangedDelegateHandle.Reset();
+	ConnectedFilterBoxWidget = nullptr;
+	ConnectedListWidget = nullptr;
+}
+
+void ASQLUISampleLayoutDrivenFilterListDemoActor::HandleLayoutDrivenFilterTextChanged(
+	const FText& InFilterText)
+{
+	if (IsValid(ConnectedListWidget.Get()))
+	{
+		ConnectedListWidget->SetFilterText(InFilterText);
+	}
+}
+
 void ASQLUISampleLayoutDrivenFilterListDemoActor::RemoveAddedRootWidget()
 {
+	DisconnectLayoutDrivenFilterListWidgets();
+
 	if (IsValid(AddedRootWidget.Get()))
 	{
 		AddedRootWidget->RemoveFromParent();

--- a/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISampleLayoutDrivenFilterListDemoActor.h
+++ b/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISampleLayoutDrivenFilterListDemoActor.h
@@ -7,6 +7,8 @@
 #include "SQLUISampleLayoutDrivenFilterListDemoActor.generated.h"
 
 class USQLUIBaseWidget;
+class USQLUIFilterBox;
+class USQLUIListWidget;
 
 UCLASS(BlueprintType)
 class SQLUISAMPLES_API ASQLUISampleLayoutDrivenFilterListDemoActor : public AActor
@@ -43,8 +45,19 @@ public:
 	FSQLUIRuntimeWidgetPipelineResult LastPipelineResult;
 
 private:
+	void ConnectLayoutDrivenFilterListWidgets();
+	void DisconnectLayoutDrivenFilterListWidgets();
+	void HandleLayoutDrivenFilterTextChanged(const FText& InFilterText);
 	void RemoveAddedRootWidget();
 
 	UPROPERTY(Transient)
 	TObjectPtr<USQLUIBaseWidget> AddedRootWidget = nullptr;
+
+	UPROPERTY(Transient)
+	TObjectPtr<USQLUIFilterBox> ConnectedFilterBoxWidget = nullptr;
+
+	UPROPERTY(Transient)
+	TObjectPtr<USQLUIListWidget> ConnectedListWidget = nullptr;
+
+	FDelegateHandle FilterTextChangedDelegateHandle;
 };

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIFilterBox.cpp
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIFilterBox.cpp
@@ -7,6 +7,11 @@
 
 namespace
 {
+bool AreSQLUIFilterBoxTextsEqual(const FText& Left, const FText& Right)
+{
+	return Left.ToString() == Right.ToString();
+}
+
 void ApplySQLUIFilterBoxVisualDefaults(UEditableTextBox& FilterTextBox)
 {
 	const FLinearColor TextColor(0.95f, 0.97f, 1.0f, 1.0f);
@@ -43,9 +48,15 @@ void ApplySQLUIFilterBoxBorderVisualDefaults(UBorder& Border)
 
 void USQLUIFilterBox::SetFilterText(const FText& InFilterText)
 {
+	if (AreSQLUIFilterBoxTextsEqual(FilterText, InFilterText))
+	{
+		return;
+	}
+
 	FilterText = InFilterText;
 	SyncFilterTextBoxText();
 	NativeOnFilterTextChanged(FilterText);
+	OnFilterTextChanged.Broadcast(FilterText);
 }
 
 FText USQLUIFilterBox::GetFilterText() const

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIListWidget.cpp
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIListWidget.cpp
@@ -21,6 +21,20 @@ FText ResolveSQLUIListEmptyText(const FText& EmptyText)
 	return EmptyText;
 }
 
+bool DoesSQLUIListItemMatchFilter(
+	const FSQLUIListItemData& ItemData,
+	const FText& FilterText)
+{
+	const FString TrimmedFilterText = FilterText.ToString().TrimStartAndEnd();
+	if (TrimmedFilterText.IsEmpty())
+	{
+		return true;
+	}
+
+	return ItemData.DisplayText.ToString().Contains(TrimmedFilterText, ESearchCase::IgnoreCase)
+		|| ItemData.ItemId.Contains(TrimmedFilterText, ESearchCase::IgnoreCase);
+}
+
 bool TryParseSQLUIListItemsProperty(
 	const FString& PropertyValue,
 	TArray<FSQLUIListItemData>& OutItems,
@@ -111,6 +125,27 @@ void USQLUIListWidget::ClearItems()
 {
 	Items.Reset();
 	NativeOnItemsChanged();
+}
+
+void USQLUIListWidget::SetFilterText(const FText& InFilterText)
+{
+	if (FilterText.ToString() == InFilterText.ToString())
+	{
+		return;
+	}
+
+	FilterText = InFilterText;
+	RebuildListItems();
+}
+
+FText USQLUIListWidget::GetFilterText() const
+{
+	return FilterText;
+}
+
+void USQLUIListWidget::ClearFilterText()
+{
+	SetFilterText(FText::GetEmpty());
 }
 
 void USQLUIListWidget::SetEmptyText(const FText& InEmptyText)
@@ -241,10 +276,27 @@ void USQLUIListWidget::RebuildListItems()
 	}
 
 	ItemWidgets.Reserve(Items.Num());
+	int32 DisplayedItemCount = 0;
 	for (const FSQLUIListItemData& ItemData : Items)
 	{
+		if (!ShouldDisplayItem(ItemData))
+		{
+			continue;
+		}
+
 		AddListItemRow(ItemData);
+		++DisplayedItemCount;
 	}
+
+	if (DisplayedItemCount == 0)
+	{
+		AddEmptyStateRow();
+	}
+}
+
+bool USQLUIListWidget::ShouldDisplayItem(const FSQLUIListItemData& ItemData) const
+{
+	return DoesSQLUIListItemMatchFilter(ItemData, FilterText);
 }
 
 void USQLUIListWidget::AddEmptyStateRow()

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIFilterBox.h
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIFilterBox.h
@@ -7,12 +7,16 @@
 
 class UEditableTextBox;
 
+DECLARE_MULTICAST_DELEGATE_OneParam(FSQLUIFilterTextChangedDelegate, const FText&);
+
 UCLASS(BlueprintType, Blueprintable)
 class SQLUIWIDGETS_API USQLUIFilterBox : public USQLUIBaseWidget
 {
 	GENERATED_BODY()
 
 public:
+	FSQLUIFilterTextChangedDelegate OnFilterTextChanged;
+
 	UFUNCTION(BlueprintCallable, Category = "SQLUI|Filter")
 	void SetFilterText(const FText& InFilterText);
 

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIListWidget.h
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIListWidget.h
@@ -28,6 +28,15 @@ public:
 	void ClearItems();
 
 	UFUNCTION(BlueprintCallable, Category = "SQLUI|List")
+	void SetFilterText(const FText& InFilterText);
+
+	UFUNCTION(BlueprintPure, Category = "SQLUI|List")
+	FText GetFilterText() const;
+
+	UFUNCTION(BlueprintCallable, Category = "SQLUI|List")
+	void ClearFilterText();
+
+	UFUNCTION(BlueprintCallable, Category = "SQLUI|List")
 	void SetEmptyText(const FText& InEmptyText);
 
 	UFUNCTION(BlueprintPure, Category = "SQLUI|List")
@@ -46,11 +55,15 @@ protected:
 private:
 	void EnsureVisualRoot();
 	void RebuildListItems();
+	bool ShouldDisplayItem(const FSQLUIListItemData& ItemData) const;
 	void AddEmptyStateRow();
 	void AddListItemRow(const FSQLUIListItemData& ItemData);
 
 	UPROPERTY(Transient, BlueprintReadOnly, Category = "SQLUI|List", meta = (AllowPrivateAccess = "true"))
 	TArray<FSQLUIListItemData> Items;
+
+	UPROPERTY(Transient, BlueprintReadOnly, Category = "SQLUI|List", meta = (AllowPrivateAccess = "true"))
+	FText FilterText;
 
 	UPROPERTY(Transient, BlueprintReadOnly, Category = "SQLUI|List", meta = (AllowPrivateAccess = "true"))
 	FText EmptyText;


### PR DESCRIPTION
Summary
- Added a narrow FilterBox text-changed notification
- Added ListWidget filter text support
- Filters visible list rows using case-insensitive substring matching
- Keeps original list item data intact while filtering displayed rows
- Connected the layout-driven sample actor’s FilterBox to its ListWidget

Validation
- Ran git diff --check
- Built JerryRiggedEditor Win64 Development successfully
- Manually tested Play-in-Editor filtering behavior

Manual test
- All rows show initially
- Typing "second" shows only the second row
- Typing "THIRD" matches the third row
- No-match text shows the empty state
- Clearing the filter restores all rows

Notes
- Does not edit maps or Content
- Does not add Blueprint assets
- Does not add SQLite/database behavior
- Does not add repository loading
- Does not implement a full reactive binding engine