### PR TITLE
Add SQLUI list row click events

### DIFF
--- a/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleLayoutDrivenFilterListDemoActor.cpp
+++ b/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleLayoutDrivenFilterListDemoActor.cpp
@@ -260,7 +260,7 @@ void ASQLUISampleLayoutDrivenFilterListDemoActor::RunLayoutDrivenFilterListDemo(
 		UE_LOG(
 			LogSQLUISamples,
 			Warning,
-			TEXT("SQLUI sample layout-driven filter/list demo skipped filter connection because the runtime pipeline failed."));
+			TEXT("SQLUI sample layout-driven filter/list demo skipped filter/list connection because the runtime pipeline failed."));
 	}
 
 	bool bAddedToViewport = false;
@@ -309,7 +309,7 @@ void ASQLUISampleLayoutDrivenFilterListDemoActor::ConnectLayoutDrivenFilterListW
 		UE_LOG(
 			LogSQLUISamples,
 			Warning,
-			TEXT("SQLUI sample layout-driven filter/list demo could not connect filter to list. FilterBox valid: %s. ListWidget valid: %s."),
+			TEXT("SQLUI sample layout-driven filter/list demo could not connect filter/list events. FilterBox valid: %s. ListWidget valid: %s."),
 			SQLUISampleLayoutDrivenFilterListDemoBoolToString(IsValid(FilterBox)),
 			SQLUISampleLayoutDrivenFilterListDemoBoolToString(IsValid(ListWidget)));
 		return;
@@ -320,6 +320,9 @@ void ASQLUISampleLayoutDrivenFilterListDemoActor::ConnectLayoutDrivenFilterListW
 	FilterTextChangedDelegateHandle = ConnectedFilterBoxWidget->OnFilterTextChanged.AddUObject(
 		this,
 		&ASQLUISampleLayoutDrivenFilterListDemoActor::HandleLayoutDrivenFilterTextChanged);
+	RowClickedDelegateHandle = ConnectedListWidget->OnRowClicked.AddUObject(
+		this,
+		&ASQLUISampleLayoutDrivenFilterListDemoActor::HandleLayoutDrivenRowClicked);
 	ConnectedListWidget->SetFilterText(ConnectedFilterBoxWidget->GetFilterText());
 
 	UE_LOG(
@@ -337,7 +340,13 @@ void ASQLUISampleLayoutDrivenFilterListDemoActor::DisconnectLayoutDrivenFilterLi
 		ConnectedFilterBoxWidget->OnFilterTextChanged.Remove(FilterTextChangedDelegateHandle);
 	}
 
+	if (IsValid(ConnectedListWidget.Get()) && RowClickedDelegateHandle.IsValid())
+	{
+		ConnectedListWidget->OnRowClicked.Remove(RowClickedDelegateHandle);
+	}
+
 	FilterTextChangedDelegateHandle.Reset();
+	RowClickedDelegateHandle.Reset();
 	ConnectedFilterBoxWidget = nullptr;
 	ConnectedListWidget = nullptr;
 }
@@ -349,6 +358,18 @@ void ASQLUISampleLayoutDrivenFilterListDemoActor::HandleLayoutDrivenFilterTextCh
 	{
 		ConnectedListWidget->SetFilterText(InFilterText);
 	}
+}
+
+void ASQLUISampleLayoutDrivenFilterListDemoActor::HandleLayoutDrivenRowClicked(
+	const FSQLUIListItemData& InItemData)
+{
+	const FString DisplayText = InItemData.DisplayText.ToString();
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample layout-driven filter/list demo row clicked. ItemId='%s', DisplayText='%s'."),
+		*InItemData.ItemId,
+		*DisplayText);
 }
 
 void ASQLUISampleLayoutDrivenFilterListDemoActor::RemoveAddedRootWidget()

--- a/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISampleLayoutDrivenFilterListDemoActor.h
+++ b/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISampleLayoutDrivenFilterListDemoActor.h
@@ -3,6 +3,7 @@
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
 #include "Pipeline/SQLUIRuntimeWidgetPipeline.h"
+#include "Widgets/SQLUIListTypes.h"
 
 #include "SQLUISampleLayoutDrivenFilterListDemoActor.generated.h"
 
@@ -48,6 +49,7 @@ private:
 	void ConnectLayoutDrivenFilterListWidgets();
 	void DisconnectLayoutDrivenFilterListWidgets();
 	void HandleLayoutDrivenFilterTextChanged(const FText& InFilterText);
+	void HandleLayoutDrivenRowClicked(const FSQLUIListItemData& InItemData);
 	void RemoveAddedRootWidget();
 
 	UPROPERTY(Transient)
@@ -60,4 +62,5 @@ private:
 	TObjectPtr<USQLUIListWidget> ConnectedListWidget = nullptr;
 
 	FDelegateHandle FilterTextChangedDelegateHandle;
+	FDelegateHandle RowClickedDelegateHandle;
 };

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIListItemWidget.cpp
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIListItemWidget.cpp
@@ -6,6 +6,7 @@
 #include "Components/TextBlock.h"
 #include "Components/VerticalBox.h"
 #include "Components/VerticalBoxSlot.h"
+#include "InputCoreTypes.h"
 
 namespace
 {
@@ -71,6 +72,24 @@ void USQLUIListItemWidget::NativeOnSQLUIWidgetInitialized()
 	Super::NativeOnSQLUIWidgetInitialized();
 	EnsureVisualRoot();
 	SyncVisualState();
+}
+
+FReply USQLUIListItemWidget::NativeOnMouseButtonDown(
+	const FGeometry& InGeometry,
+	const FPointerEvent& InMouseEvent)
+{
+	if (InMouseEvent.GetEffectingButton() == EKeys::LeftMouseButton)
+	{
+		NativeOnListItemClicked(ListItemData);
+		OnListItemClicked.Broadcast(ListItemData);
+		return FReply::Handled();
+	}
+
+	return Super::NativeOnMouseButtonDown(InGeometry, InMouseEvent);
+}
+
+void USQLUIListItemWidget::NativeOnListItemClicked(const FSQLUIListItemData& InListItemData)
+{
 }
 
 void USQLUIListItemWidget::NativeOnListItemDataChanged()

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIListWidget.cpp
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIListWidget.cpp
@@ -178,6 +178,10 @@ void USQLUIListWidget::NativeOnItemsChanged()
 	RebuildListItems();
 }
 
+void USQLUIListWidget::NativeOnRowClicked(const FSQLUIListItemData& InItemData)
+{
+}
+
 bool USQLUIListWidget::NativeApplySQLUIWidgetProperty(
 	const FString& PropertyName,
 	const FString& PropertyValue,
@@ -336,10 +340,17 @@ void USQLUIListWidget::AddListItemRow(const FSQLUIListItemData& ItemData)
 	}
 
 	ItemWidget->SetListItemData(ItemData);
+	ItemWidget->OnListItemClicked.AddUObject(this, &USQLUIListWidget::HandleListItemClicked);
 	ItemWidgets.Add(ItemWidget);
 
 	if (UVerticalBoxSlot* ItemSlot = ItemContainer->AddChildToVerticalBox(ItemWidget))
 	{
 		ItemSlot->SetPadding(FMargin(0.0f, 0.0f, 0.0f, 6.0f));
 	}
+}
+
+void USQLUIListWidget::HandleListItemClicked(const FSQLUIListItemData& InItemData)
+{
+	NativeOnRowClicked(InItemData);
+	OnRowClicked.Broadcast(InItemData);
 }

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIListItemWidget.h
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIListItemWidget.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Input/Events.h"
+#include "Input/Reply.h"
+#include "Layout/Geometry.h"
 #include "Widgets/SQLUIBaseWidget.h"
 #include "Widgets/SQLUIListTypes.h"
 
@@ -16,6 +19,8 @@ class SQLUIWIDGETS_API USQLUIListItemWidget : public USQLUIBaseWidget
 	GENERATED_BODY()
 
 public:
+	FSQLUIListItemClickedDelegate OnListItemClicked;
+
 	UFUNCTION(BlueprintCallable, Category = "SQLUI|List")
 	void SetListItemData(const FSQLUIListItemData& InListItemData);
 
@@ -25,6 +30,8 @@ public:
 protected:
 	virtual void NativeOnInitialized() override;
 	virtual void NativeOnSQLUIWidgetInitialized() override;
+	virtual FReply NativeOnMouseButtonDown(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent) override;
+	virtual void NativeOnListItemClicked(const FSQLUIListItemData& InListItemData);
 	virtual void NativeOnListItemDataChanged();
 	virtual bool NativeApplySQLUIWidgetProperty(
 		const FString& PropertyName,

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIListTypes.h
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIListTypes.h
@@ -21,3 +21,5 @@ struct SQLUIWIDGETS_API FSQLUIListItemData
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|List")
 	TMap<FString, FString> Metadata;
 };
+
+DECLARE_MULTICAST_DELEGATE_OneParam(FSQLUIListItemClickedDelegate, const FSQLUIListItemData&);

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIListWidget.h
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIListWidget.h
@@ -18,6 +18,8 @@ class SQLUIWIDGETS_API USQLUIListWidget : public USQLUIBaseWidget
 	GENERATED_BODY()
 
 public:
+	FSQLUIListItemClickedDelegate OnRowClicked;
+
 	UFUNCTION(BlueprintCallable, Category = "SQLUI|List")
 	void SetItems(const TArray<FSQLUIListItemData>& InItems);
 
@@ -46,6 +48,7 @@ protected:
 	virtual void NativeOnInitialized() override;
 	virtual void NativeOnSQLUIWidgetInitialized() override;
 	virtual void NativeOnItemsChanged();
+	virtual void NativeOnRowClicked(const FSQLUIListItemData& InItemData);
 	virtual bool NativeApplySQLUIWidgetProperty(
 		const FString& PropertyName,
 		const FString& PropertyValue,
@@ -58,6 +61,7 @@ private:
 	bool ShouldDisplayItem(const FSQLUIListItemData& ItemData) const;
 	void AddEmptyStateRow();
 	void AddListItemRow(const FSQLUIListItemData& ItemData);
+	void HandleListItemClicked(const FSQLUIListItemData& InItemData);
 
 	UPROPERTY(Transient, BlueprintReadOnly, Category = "SQLUI|List", meta = (AllowPrivateAccess = "true"))
 	TArray<FSQLUIListItemData> Items;

--- a/Plugins/SQLUI/Source/SQLUIWidgets/SQLUIWidgets.Build.cs
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/SQLUIWidgets.Build.cs
@@ -17,6 +17,7 @@ public class SQLUIWidgets : ModuleRules
 
 		PrivateDependencyModuleNames.AddRange(new string[]
 		{
+			"InputCore",
 			"Slate",
 			"SlateCore"
 		});


### PR DESCRIPTION
## Summary
- Added a shared SQLUI list item click delegate payload type
- Broadcast left-clicks from `USQLUIListItemWidget`
- Routed row clicks through `USQLUIListWidget::OnRowClicked`
- Connected the layout-driven FilterBox/ListWidget sample to log row-click actions
- Added the narrow `InputCore` dependency required for mouse-button checks

## Validation
- Reviewed branch diff against `main`
- Not run locally in this chat environment: Unreal Editor build / Play-in-Editor manual test

## Notes
- Does not edit maps or Content
- Does not add Blueprint assets
- Does not add SQLite/database behavior
- Does not add repository loading
- Keeps the new click path source-only and reusable