### PR TITLE
Wire SQLUI row-click layout actions

### DIFF
--- a/Plugins/SQLUI/Source/SQLUICore/Private/WidgetCatalog/SQLUIWidgetCatalog.cpp
+++ b/Plugins/SQLUI/Source/SQLUICore/Private/WidgetCatalog/SQLUIWidgetCatalog.cpp
@@ -73,6 +73,11 @@ void ValidateSQLUIWidgetCatalogKey(
 		return;
 	}
 
+	if (SupportedKeys.IsEmpty())
+	{
+		return;
+	}
+
 	if (!SupportedKeys.Contains(Key))
 	{
 		AddSQLUIWidgetCatalogValidationError(

--- a/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleLayoutDrivenFilterListDemoActor.cpp
+++ b/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleLayoutDrivenFilterListDemoActor.cpp
@@ -1,5 +1,6 @@
 #include "SQLUISampleLayoutDrivenFilterListDemoActor.h"
 
+#include "Actions/SQLUIActionRegistry.h"
 #include "SQLUISamplesModule.h"
 #include "Engine/World.h"
 #include "GameFramework/PlayerController.h"
@@ -18,6 +19,8 @@ const TCHAR* SQLUISampleLayoutDrivenFilterListFilterBoxWidgetId =
 	TEXT("SQLUI.Sample.LayoutDrivenFilterList.FilterBox");
 const TCHAR* SQLUISampleLayoutDrivenFilterListListWidgetId =
 	TEXT("SQLUI.Sample.LayoutDrivenFilterList.ListWidget");
+const TCHAR* SQLUISampleLayoutDrivenFilterListRowClickedActionKey =
+	TEXT("SQLUI.Sample.LogRowClicked");
 
 const TCHAR* SQLUISampleLayoutDrivenFilterListDemoStepStatusToString(
 	const ESQLUIRuntimeWidgetPipelineStepStatus Status)
@@ -40,6 +43,36 @@ const TCHAR* SQLUISampleLayoutDrivenFilterListDemoStepStatusToString(
 const TCHAR* SQLUISampleLayoutDrivenFilterListDemoBoolToString(const bool bValue)
 {
 	return bValue ? TEXT("true") : TEXT("false");
+}
+
+FString GetSQLUISampleActionParameterString(
+	const FSQLUIActionRequest& Request,
+	const FString& ParameterName)
+{
+	const FSQLUIVariableValue* Value = Request.Parameters.Find(ParameterName);
+	if (!Value)
+	{
+		return FString();
+	}
+
+	switch (Value->Type)
+	{
+	case ESQLUIVariableValueType::String:
+		return Value->StringValue;
+	case ESQLUIVariableValueType::Number:
+		return FString::SanitizeFloat(Value->NumberValue);
+	case ESQLUIVariableValueType::Boolean:
+		return SQLUISampleLayoutDrivenFilterListDemoBoolToString(Value->bBooleanValue);
+	default:
+		return FString();
+	}
+}
+
+FSQLUIActionResult MakeSQLUISampleSucceededActionResult()
+{
+	FSQLUIActionResult Result;
+	Result.bSucceeded = true;
+	return Result;
 }
 
 void LogSQLUISampleLayoutDrivenFilterListDemoErrors(const TArray<FString>& Messages)
@@ -110,6 +143,12 @@ FSQLUILayoutDocument MakeSQLUISampleLayoutDrivenFilterListDocument()
 	FilterBoxNode.Properties.Add(TEXT("PlaceholderText"), TEXT("Filter layout-driven sample rows"));
 	FilterBoxNode.Properties.Add(TEXT("IsEnabled"), TEXT("true"));
 
+	FSQLUILayoutAction RowClickedAction;
+	RowClickedAction.ActionId = TEXT("SQLUI.Sample.LayoutDrivenFilterList.RowClicked");
+	RowClickedAction.Trigger = TEXT("RowClicked");
+	RowClickedAction.ActionTypeKey = SQLUISampleLayoutDrivenFilterListRowClickedActionKey;
+	RowClickedAction.Parameters.Add(TEXT("Source"), TEXT("LayoutDrivenFilterListDemo"));
+
 	FSQLUILayoutNode ListWidgetNode;
 	ListWidgetNode.WidgetId = ListWidgetId;
 	ListWidgetNode.ParentWidgetId = RootWidgetId;
@@ -117,6 +156,7 @@ FSQLUILayoutDocument MakeSQLUISampleLayoutDrivenFilterListDocument()
 	ListWidgetNode.Properties.Add(TEXT("EmptyText"), TEXT("No layout-driven sample rows yet"));
 	ListWidgetNode.Properties.Add(TEXT("Items"), TEXT("row-1|First sample row;row-2|Second sample row;row-3|Third sample row"));
 	ListWidgetNode.Properties.Add(TEXT("IsEnabled"), TEXT("true"));
+	ListWidgetNode.Actions.Add(RowClickedAction);
 
 	Document.Nodes.Add(RootNode);
 	Document.Nodes.Add(FilterBoxNode);
@@ -203,6 +243,33 @@ void ASQLUISampleLayoutDrivenFilterListDemoActor::RunLayoutDrivenFilterListDemo(
 		return;
 	}
 
+	USQLUIActionRegistry* ActionRegistry = NewObject<USQLUIActionRegistry>(this);
+	if (!IsValid(ActionRegistry))
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample layout-driven filter/list demo failed: could not create action registry."));
+		LogSQLUISampleLayoutDrivenFilterListDemoResult(LastPipelineResult);
+		return;
+	}
+
+	FSQLUIActionKey RowClickedActionKey;
+	RowClickedActionKey.Name = SQLUISampleLayoutDrivenFilterListRowClickedActionKey;
+	if (!ActionRegistry->RegisterAction(
+		RowClickedActionKey,
+		FSQLUIActionHandler::CreateUObject(
+			this,
+			&ASQLUISampleLayoutDrivenFilterListDemoActor::HandleLayoutDrivenRowClickedAction)))
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample layout-driven filter/list demo failed: could not register row-click action handler."));
+		LogSQLUISampleLayoutDrivenFilterListDemoResult(LastPipelineResult);
+		return;
+	}
+
 	USQLUIRuntimeContext* RuntimeContext = NewObject<USQLUIRuntimeContext>(this);
 	if (!IsValid(RuntimeContext))
 	{
@@ -215,6 +282,7 @@ void ASQLUISampleLayoutDrivenFilterListDemoActor::RunLayoutDrivenFilterListDemo(
 	}
 
 	FSQLUIRuntimeContextSettings RuntimeContextSettings;
+	RuntimeContextSettings.ActionRegistry = ActionRegistry;
 	RuntimeContextSettings.WidgetCatalog = WidgetCatalog;
 	RuntimeContext->Initialize(RuntimeContextSettings);
 
@@ -320,9 +388,6 @@ void ASQLUISampleLayoutDrivenFilterListDemoActor::ConnectLayoutDrivenFilterListW
 	FilterTextChangedDelegateHandle = ConnectedFilterBoxWidget->OnFilterTextChanged.AddUObject(
 		this,
 		&ASQLUISampleLayoutDrivenFilterListDemoActor::HandleLayoutDrivenFilterTextChanged);
-	RowClickedDelegateHandle = ConnectedListWidget->OnRowClicked.AddUObject(
-		this,
-		&ASQLUISampleLayoutDrivenFilterListDemoActor::HandleLayoutDrivenRowClicked);
 	ConnectedListWidget->SetFilterText(ConnectedFilterBoxWidget->GetFilterText());
 
 	UE_LOG(
@@ -340,13 +405,7 @@ void ASQLUISampleLayoutDrivenFilterListDemoActor::DisconnectLayoutDrivenFilterLi
 		ConnectedFilterBoxWidget->OnFilterTextChanged.Remove(FilterTextChangedDelegateHandle);
 	}
 
-	if (IsValid(ConnectedListWidget.Get()) && RowClickedDelegateHandle.IsValid())
-	{
-		ConnectedListWidget->OnRowClicked.Remove(RowClickedDelegateHandle);
-	}
-
 	FilterTextChangedDelegateHandle.Reset();
-	RowClickedDelegateHandle.Reset();
 	ConnectedFilterBoxWidget = nullptr;
 	ConnectedListWidget = nullptr;
 }
@@ -360,16 +419,24 @@ void ASQLUISampleLayoutDrivenFilterListDemoActor::HandleLayoutDrivenFilterTextCh
 	}
 }
 
-void ASQLUISampleLayoutDrivenFilterListDemoActor::HandleLayoutDrivenRowClicked(
-	const FSQLUIListItemData& InItemData)
+FSQLUIActionResult ASQLUISampleLayoutDrivenFilterListDemoActor::HandleLayoutDrivenRowClickedAction(
+	const FSQLUIActionRequest& Request)
 {
-	const FString DisplayText = InItemData.DisplayText.ToString();
+	const FString ActionId = GetSQLUISampleActionParameterString(Request, TEXT("ActionId"));
+	const FString WidgetId = GetSQLUISampleActionParameterString(Request, TEXT("WidgetId"));
+	const FString ItemId = GetSQLUISampleActionParameterString(Request, TEXT("ItemId"));
+	const FString DisplayText = GetSQLUISampleActionParameterString(Request, TEXT("DisplayText"));
+
 	UE_LOG(
 		LogSQLUISamples,
 		Log,
-		TEXT("SQLUI sample layout-driven filter/list demo row clicked. ItemId='%s', DisplayText='%s'."),
-		*InItemData.ItemId,
+		TEXT("SQLUI sample layout-driven filter/list demo row-click action dispatched. ActionId='%s', WidgetId='%s', ItemId='%s', DisplayText='%s'."),
+		*ActionId,
+		*WidgetId,
+		*ItemId,
 		*DisplayText);
+
+	return MakeSQLUISampleSucceededActionResult();
 }
 
 void ASQLUISampleLayoutDrivenFilterListDemoActor::RemoveAddedRootWidget()

--- a/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISampleLayoutDrivenFilterListDemoActor.h
+++ b/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISampleLayoutDrivenFilterListDemoActor.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "Actions/SQLUIActionTypes.h"
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
 #include "Pipeline/SQLUIRuntimeWidgetPipeline.h"
-#include "Widgets/SQLUIListTypes.h"
 
 #include "SQLUISampleLayoutDrivenFilterListDemoActor.generated.h"
 
@@ -49,7 +49,7 @@ private:
 	void ConnectLayoutDrivenFilterListWidgets();
 	void DisconnectLayoutDrivenFilterListWidgets();
 	void HandleLayoutDrivenFilterTextChanged(const FText& InFilterText);
-	void HandleLayoutDrivenRowClicked(const FSQLUIListItemData& InItemData);
+	FSQLUIActionResult HandleLayoutDrivenRowClickedAction(const FSQLUIActionRequest& Request);
 	void RemoveAddedRootWidget();
 
 	UPROPERTY(Transient)
@@ -62,5 +62,4 @@ private:
 	TObjectPtr<USQLUIListWidget> ConnectedListWidget = nullptr;
 
 	FDelegateHandle FilterTextChangedDelegateHandle;
-	FDelegateHandle RowClickedDelegateHandle;
 };

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Private/Actions/SQLUIWidgetActionApplier.cpp
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Private/Actions/SQLUIWidgetActionApplier.cpp
@@ -5,9 +5,13 @@
 #include "Variables/SQLUIVariableTypes.h"
 #include "WidgetCatalog/SQLUIWidgetCatalog.h"
 #include "Widgets/SQLUIBaseWidget.h"
+#include "Widgets/SQLUIListWidget.h"
 
 namespace
 {
+const TCHAR* SQLUIWidgetActionTriggerRowClicked = TEXT("RowClicked");
+const TCHAR* SQLUIWidgetActionTriggerOnRowClicked = TEXT("OnRowClicked");
+
 FString GetSQLUIWidgetActionLabel(const FSQLUILayoutAction& Action)
 {
 	if (!Action.ActionId.IsEmpty())
@@ -231,10 +235,29 @@ FSQLUIVariableValue MakeSQLUIActionParameterValue(const FString& ParameterValue)
 	return Value;
 }
 
-FSQLUIActionRequest MakeSQLUIActionRequest(const FSQLUILayoutAction& Action)
+void AddSQLUIActionRequestStringParameter(
+	TMap<FString, FSQLUIVariableValue>& Parameters,
+	const FString& Key,
+	const FString& Value)
+{
+	if (!Key.IsEmpty())
+	{
+		Parameters.Add(Key, MakeSQLUIActionParameterValue(Value));
+	}
+}
+
+FSQLUIActionRequest MakeSQLUIActionRequest(
+	const FSQLUILayoutNode& LayoutNode,
+	const FSQLUILayoutAction& Action)
 {
 	FSQLUIActionRequest ActionRequest;
 	ActionRequest.ActionKey.Name = Action.ActionTypeKey;
+
+	AddSQLUIActionRequestStringParameter(ActionRequest.Parameters, TEXT("WidgetId"), LayoutNode.WidgetId);
+	AddSQLUIActionRequestStringParameter(ActionRequest.Parameters, TEXT("WidgetTypeKey"), LayoutNode.WidgetTypeKey);
+	AddSQLUIActionRequestStringParameter(ActionRequest.Parameters, TEXT("ActionId"), Action.ActionId);
+	AddSQLUIActionRequestStringParameter(ActionRequest.Parameters, TEXT("Trigger"), Action.Trigger);
+	AddSQLUIActionRequestStringParameter(ActionRequest.Parameters, TEXT("ActionTypeKey"), Action.ActionTypeKey);
 
 	for (const TPair<FString, FString>& ParameterPair : Action.Parameters)
 	{
@@ -272,12 +295,70 @@ bool IsSQLUIWidgetActionSupportedByCatalog(
 	}
 
 	const FSQLUIWidgetCatalogEntry* CatalogEntry = WidgetCatalog->FindEntry(LayoutNode.WidgetTypeKey);
-	if (!CatalogEntry)
+	if (!CatalogEntry || CatalogEntry->SupportedActionKeys.IsEmpty())
 	{
 		return true;
 	}
 
 	return CatalogEntry->SupportedActionKeys.Contains(Action.ActionTypeKey);
+}
+
+bool IsSQLUIRowClickedTrigger(const FString& Trigger)
+{
+	return Trigger.Equals(SQLUIWidgetActionTriggerRowClicked, ESearchCase::IgnoreCase)
+		|| Trigger.Equals(SQLUIWidgetActionTriggerOnRowClicked, ESearchCase::IgnoreCase);
+}
+
+void ClearSQLUIWidgetEventActions(USQLUIBaseWidget* Widget)
+{
+	if (USQLUIListWidget* ListWidget = Cast<USQLUIListWidget>(Widget))
+	{
+		ListWidget->ClearRowClickActions();
+	}
+}
+
+bool TryBindSQLUIWidgetEventAction(
+	USQLUIBaseWidget* Widget,
+	const FSQLUILayoutNode& LayoutNode,
+	const FSQLUILayoutAction& Action,
+	const FSQLUIActionRequest& ActionRequest,
+	FSQLUIAppliedWidgetAction& AppliedAction,
+	FSQLUIWidgetActionApplyResult& Result,
+	const bool bFailOnUnsupportedActions)
+{
+	if (!IsSQLUIRowClickedTrigger(Action.Trigger))
+	{
+		return false;
+	}
+
+	USQLUIListWidget* ListWidget = Cast<USQLUIListWidget>(Widget);
+	if (!IsValid(ListWidget))
+	{
+		AppliedAction.bUnsupportedAction = true;
+		AppliedAction.bSkipped = true;
+		AppliedAction.bFailed = bFailOnUnsupportedActions;
+		Result.AppliedActions.Add(AppliedAction);
+
+		AddSQLUIWidgetActionApplyProblem(
+			Result,
+			bFailOnUnsupportedActions,
+			LayoutNode.WidgetId,
+			Action,
+			FString::Printf(
+				TEXT("%s uses row-click trigger '%s', but widget type '%s' does not support row-click action binding."),
+				*MakeSQLUIWidgetActionMessagePrefix(LayoutNode.WidgetId, Action),
+				*Action.Trigger,
+				*LayoutNode.WidgetTypeKey),
+			false,
+			true);
+		return true;
+	}
+
+	ListWidget->AddRowClickAction(ActionRequest);
+	AppliedAction.bBoundToEvent = true;
+	AppliedAction.bSucceeded = true;
+	Result.AppliedActions.Add(AppliedAction);
+	return true;
 }
 }
 
@@ -317,6 +398,8 @@ FSQLUIWidgetActionApplyResult USQLUIWidgetActionApplier::ApplyActions(
 			continue;
 		}
 
+		ClearSQLUIWidgetEventActions(Widget);
+
 		for (const FSQLUILayoutAction& Action : LayoutNode.Actions)
 		{
 			FSQLUIActionRequest ActionRequest;
@@ -350,12 +433,12 @@ FSQLUIWidgetActionApplyResult USQLUIWidgetActionApplier::ApplyActions(
 					LayoutNode.WidgetId,
 					Action,
 					FString::Printf(
-						TEXT("%s does not include a trigger. The action was prepared for later event wiring only."),
+						TEXT("%s does not include a trigger. It will only run immediately when registered action execution is enabled."),
 						*MakeSQLUIWidgetActionMessagePrefix(LayoutNode.WidgetId, Action)),
 					true);
 			}
 
-			ActionRequest = MakeSQLUIActionRequest(Action);
+			ActionRequest = MakeSQLUIActionRequest(LayoutNode, Action);
 			AppliedAction = MakeSQLUIAppliedWidgetAction(
 				LayoutNode.WidgetId,
 				Action,
@@ -429,6 +512,33 @@ FSQLUIWidgetActionApplyResult USQLUIWidgetActionApplier::ApplyActions(
 					false,
 					false,
 					true);
+				continue;
+			}
+
+			if (TryBindSQLUIWidgetEventAction(
+				Widget,
+				LayoutNode,
+				Action,
+				ActionRequest,
+				AppliedAction,
+				Result,
+				Request.bFailOnUnsupportedActions))
+			{
+				continue;
+			}
+
+			if (!Action.Trigger.IsEmpty())
+			{
+				AppliedAction.bSkipped = true;
+				Result.AppliedActions.Add(AppliedAction);
+				AddSQLUIWidgetActionApplyWarning(
+					Result,
+					LayoutNode.WidgetId,
+					Action,
+					FString::Printf(
+						TEXT("%s uses trigger '%s', but this trigger is not wired to a runtime widget event yet."),
+						*MakeSQLUIWidgetActionMessagePrefix(LayoutNode.WidgetId, Action),
+						*Action.Trigger));
 				continue;
 			}
 

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIListWidget.cpp
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Private/Widgets/SQLUIListWidget.cpp
@@ -1,5 +1,6 @@
 #include "Widgets/SQLUIListWidget.h"
 
+#include "Actions/SQLUIActionRegistry.h"
 #include "Blueprint/WidgetTree.h"
 #include "Brushes/SlateColorBrush.h"
 #include "Components/Border.h"
@@ -7,6 +8,7 @@
 #include "Components/TextBlock.h"
 #include "Components/VerticalBox.h"
 #include "Components/VerticalBoxSlot.h"
+#include "Runtime/SQLUIRuntimeContext.h"
 #include "Widgets/SQLUIListItemWidget.h"
 
 namespace
@@ -91,6 +93,37 @@ bool TryParseSQLUIListItemsProperty(
 	return true;
 }
 
+FSQLUIVariableValue MakeSQLUIListActionStringParameterValue(const FString& InValue)
+{
+	FSQLUIVariableValue Value;
+	Value.Type = ESQLUIVariableValueType::String;
+	Value.StringValue = InValue;
+	return Value;
+}
+
+void AddSQLUIListActionStringParameter(
+	TMap<FString, FSQLUIVariableValue>& Parameters,
+	const FString& Key,
+	const FString& Value)
+{
+	if (!Key.IsEmpty())
+	{
+		Parameters.Add(Key, MakeSQLUIListActionStringParameterValue(Value));
+	}
+}
+
+FSQLUIActionResult MakeSQLUIListUnavailableActionResult(const FString& ActionName, const FString& Reason)
+{
+	FSQLUIActionResult Result;
+	Result.bSucceeded = false;
+	Result.bActionUnavailable = true;
+	Result.bNotImplemented = true;
+	Result.ErrorMessage = ActionName.IsEmpty()
+		? Reason
+		: FString::Printf(TEXT("SQLUI list row-click action '%s' is unavailable: %s"), *ActionName, *Reason);
+	return Result;
+}
+
 void ApplySQLUIListBorderDefaults(UBorder& Border)
 {
 	Border.SetBrush(FSlateColorBrush(FLinearColor(0.018f, 0.024f, 0.034f, 0.96f)));
@@ -159,6 +192,26 @@ FText USQLUIListWidget::GetEmptyText() const
 	return ResolveSQLUIListEmptyText(EmptyText);
 }
 
+void USQLUIListWidget::SetRowClickActions(const TArray<FSQLUIActionRequest>& InActionRequests)
+{
+	RowClickActionRequests = InActionRequests;
+}
+
+void USQLUIListWidget::AddRowClickAction(const FSQLUIActionRequest& InActionRequest)
+{
+	RowClickActionRequests.Add(InActionRequest);
+}
+
+void USQLUIListWidget::ClearRowClickActions()
+{
+	RowClickActionRequests.Reset();
+}
+
+TArray<FSQLUIActionRequest> USQLUIListWidget::GetRowClickActions() const
+{
+	return RowClickActionRequests;
+}
+
 void USQLUIListWidget::NativeOnInitialized()
 {
 	Super::NativeOnInitialized();
@@ -180,6 +233,37 @@ void USQLUIListWidget::NativeOnItemsChanged()
 
 void USQLUIListWidget::NativeOnRowClicked(const FSQLUIListItemData& InItemData)
 {
+	ExecuteRowClickActions(InItemData);
+}
+
+FSQLUIActionResult USQLUIListWidget::NativeExecuteRowClickAction(
+	const FSQLUIActionRequest& InActionRequest,
+	const FSQLUIListItemData& InItemData)
+{
+	USQLUIRuntimeContext* RuntimeContext = GetSQLUIRuntimeContext();
+	if (!IsValid(RuntimeContext))
+	{
+		return MakeSQLUIListUnavailableActionResult(
+			InActionRequest.ActionKey.Name,
+			TEXT("no runtime context is available."));
+	}
+
+	if (!RuntimeContext->IsInitialized())
+	{
+		return MakeSQLUIListUnavailableActionResult(
+			InActionRequest.ActionKey.Name,
+			TEXT("the runtime context is not initialized."));
+	}
+
+	USQLUIActionRegistry* ActionRegistry = RuntimeContext->GetActionRegistry();
+	if (!IsValid(ActionRegistry))
+	{
+		return MakeSQLUIListUnavailableActionResult(
+			InActionRequest.ActionKey.Name,
+			TEXT("no action registry is available."));
+	}
+
+	return ActionRegistry->ExecuteAction(InActionRequest);
 }
 
 bool USQLUIListWidget::NativeApplySQLUIWidgetProperty(
@@ -353,4 +437,49 @@ void USQLUIListWidget::HandleListItemClicked(const FSQLUIListItemData& InItemDat
 {
 	NativeOnRowClicked(InItemData);
 	OnRowClicked.Broadcast(InItemData);
+}
+
+void USQLUIListWidget::ExecuteRowClickActions(const FSQLUIListItemData& InItemData)
+{
+	for (const FSQLUIActionRequest& RowClickActionRequest : RowClickActionRequests)
+	{
+		NativeExecuteRowClickAction(MakeRowClickActionRequest(RowClickActionRequest, InItemData), InItemData);
+	}
+}
+
+FSQLUIActionRequest USQLUIListWidget::MakeRowClickActionRequest(
+	const FSQLUIActionRequest& InActionRequest,
+	const FSQLUIListItemData& InItemData) const
+{
+	FSQLUIActionRequest RowClickActionRequest = InActionRequest;
+	AddSQLUIListActionStringParameter(RowClickActionRequest.Parameters, TEXT("WidgetId"), GetSQLUIWidgetId());
+	AddSQLUIListActionStringParameter(RowClickActionRequest.Parameters, TEXT("WidgetTypeKey"), GetSQLUIWidgetTypeKey());
+	AddSQLUIListActionStringParameter(RowClickActionRequest.Parameters, TEXT("ItemId"), InItemData.ItemId);
+	AddSQLUIListActionStringParameter(RowClickActionRequest.Parameters, TEXT("RowItemId"), InItemData.ItemId);
+	AddSQLUIListActionStringParameter(RowClickActionRequest.Parameters, TEXT("DisplayText"), InItemData.DisplayText.ToString());
+	AddSQLUIListActionStringParameter(RowClickActionRequest.Parameters, TEXT("RowDisplayText"), InItemData.DisplayText.ToString());
+
+	for (const TPair<FString, FString>& PropertyPair : InItemData.Properties)
+	{
+		if (!PropertyPair.Key.IsEmpty())
+		{
+			AddSQLUIListActionStringParameter(
+				RowClickActionRequest.Parameters,
+				FString::Printf(TEXT("RowProperty.%s"), *PropertyPair.Key),
+				PropertyPair.Value);
+		}
+	}
+
+	for (const TPair<FString, FString>& MetadataPair : InItemData.Metadata)
+	{
+		if (!MetadataPair.Key.IsEmpty())
+		{
+			AddSQLUIListActionStringParameter(
+				RowClickActionRequest.Parameters,
+				FString::Printf(TEXT("RowMetadata.%s"), *MetadataPair.Key),
+				MetadataPair.Value);
+		}
+	}
+
+	return RowClickActionRequest;
 }

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Public/Actions/SQLUIWidgetActionTypes.h
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Public/Actions/SQLUIWidgetActionTypes.h
@@ -110,6 +110,9 @@ struct SQLUIWIDGETS_API FSQLUIAppliedWidgetAction
 	bool bRegistered = false;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Actions")
+	bool bBoundToEvent = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Actions")
 	bool bExecuted = false;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Widget Actions")

--- a/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIListWidget.h
+++ b/Plugins/SQLUI/Source/SQLUIWidgets/Public/Widgets/SQLUIListWidget.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Actions/SQLUIActionTypes.h"
 #include "CoreMinimal.h"
 #include "Widgets/SQLUIBaseWidget.h"
 #include "Widgets/SQLUIListTypes.h"
@@ -44,11 +45,19 @@ public:
 	UFUNCTION(BlueprintPure, Category = "SQLUI|List")
 	FText GetEmptyText() const;
 
+	void SetRowClickActions(const TArray<FSQLUIActionRequest>& InActionRequests);
+	void AddRowClickAction(const FSQLUIActionRequest& InActionRequest);
+	void ClearRowClickActions();
+	TArray<FSQLUIActionRequest> GetRowClickActions() const;
+
 protected:
 	virtual void NativeOnInitialized() override;
 	virtual void NativeOnSQLUIWidgetInitialized() override;
 	virtual void NativeOnItemsChanged();
 	virtual void NativeOnRowClicked(const FSQLUIListItemData& InItemData);
+	virtual FSQLUIActionResult NativeExecuteRowClickAction(
+		const FSQLUIActionRequest& InActionRequest,
+		const FSQLUIListItemData& InItemData);
 	virtual bool NativeApplySQLUIWidgetProperty(
 		const FString& PropertyName,
 		const FString& PropertyValue,
@@ -62,6 +71,10 @@ private:
 	void AddEmptyStateRow();
 	void AddListItemRow(const FSQLUIListItemData& ItemData);
 	void HandleListItemClicked(const FSQLUIListItemData& InItemData);
+	void ExecuteRowClickActions(const FSQLUIListItemData& InItemData);
+	FSQLUIActionRequest MakeRowClickActionRequest(
+		const FSQLUIActionRequest& InActionRequest,
+		const FSQLUIListItemData& InItemData) const;
 
 	UPROPERTY(Transient, BlueprintReadOnly, Category = "SQLUI|List", meta = (AllowPrivateAccess = "true"))
 	TArray<FSQLUIListItemData> Items;
@@ -71,6 +84,9 @@ private:
 
 	UPROPERTY(Transient, BlueprintReadOnly, Category = "SQLUI|List", meta = (AllowPrivateAccess = "true"))
 	FText EmptyText;
+
+	UPROPERTY(Transient)
+	TArray<FSQLUIActionRequest> RowClickActionRequests;
 
 	UPROPERTY(Transient)
 	TObjectPtr<UBorder> ListBorder = nullptr;


### PR DESCRIPTION
## Summary
- Added row-click action request storage/execution to `USQLUIListWidget`
- Bound layout actions with `RowClicked` / `OnRowClicked` triggers through `USQLUIWidgetActionApplier`
- Added row payload parameters such as `ItemId`, `DisplayText`, `RowProperty.*`, and `RowMetadata.*`
- Updated the layout-driven FilterBox/ListWidget sample to declare a row-click action in layout data
- Registered a sample runtime action handler through `USQLUIActionRegistry` and `USQLUIRuntimeContext`
- Fixed widget catalog layout validation so an empty supported-action-key list means unrestricted, matching action-applier behavior

## Validation
- Codex ran `git status`
- Codex ran `git diff --check main...HEAD`
- Codex built `JerryRiggedEditor Win64 Development` successfully after the source fix
- Codex ran `Scripts/RunSQLUISmokeTest.ps1` successfully with the local UE 5.7 engine root
- Codex verified the existing SQLUI smoke commandlet completed with all pipeline steps succeeding, including `ApplyActions`
- Codex validated in Play-in-Editor/manual testing that:
  - rows displayed initially: `row-1`, `row-2`, `row-3`
  - filtering with `Second` showed only `row-2`
  - clearing the filter restored all rows
  - clicking `row-2` dispatched the action
  - the log included `ActionId='SQLUI.Sample.LayoutDrivenFilterList.RowClicked'`, `WidgetId='SQLUI.Sample.LayoutDrivenFilterList.ListWidget'`, `ItemId='row-2'`, and `DisplayText='Second sample row'`
- Codex confirmed no map or Content assets were modified

## Notes
- Does not edit maps or Content
- Does not add Blueprint assets
- Does not add SQLite/database behavior
- Does not add repository loading
- Keeps row-click dispatch source-only and layout-driven