### PR TITLE
Add SQLUI repository operation smoke coverage

### DIFF
--- a/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleSmokeTestCommandlet.cpp
+++ b/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleSmokeTestCommandlet.cpp
@@ -121,6 +121,86 @@ void LogSQLUISampleSmokeTestRepositoryValidationMessages(
 	}
 }
 
+void LogSQLUISampleSmokeTestRepositoryOperationResult(
+	const TCHAR* RepositoryName,
+	const FSQLUISampleRepositoryOperationSmokeResult& Result)
+{
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample smoke test %s list after save %s. LayoutCount=%d MetadataFound=%s"),
+		RepositoryName,
+		Result.bListAfterSaveSucceeded ? TEXT("succeeded") : TEXT("failed"),
+		Result.ListAfterSaveLayoutCount,
+		Result.bSavedLayoutMetadataFound ? TEXT("true") : TEXT("false"));
+
+	if (!Result.ListAfterSaveErrorMessage.IsEmpty())
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample smoke test %s list after save error: %s"),
+			RepositoryName,
+			*Result.ListAfterSaveErrorMessage);
+	}
+
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample smoke test %s remove %s. Removed=%s"),
+		RepositoryName,
+		Result.bRemoveSucceeded ? TEXT("succeeded") : TEXT("failed"),
+		Result.bSavedLayoutRemoved ? TEXT("true") : TEXT("false"));
+
+	if (!Result.RemoveErrorMessage.IsEmpty())
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample smoke test %s remove error: %s"),
+			RepositoryName,
+			*Result.RemoveErrorMessage);
+	}
+
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample smoke test %s list after remove %s. LayoutCount=%d MetadataAbsent=%s"),
+		RepositoryName,
+		Result.bListAfterRemoveSucceeded ? TEXT("succeeded") : TEXT("failed"),
+		Result.ListAfterRemoveLayoutCount,
+		Result.bRemovedLayoutMetadataAbsent ? TEXT("true") : TEXT("false"));
+
+	if (!Result.ListAfterRemoveErrorMessage.IsEmpty())
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample smoke test %s list after remove error: %s"),
+			RepositoryName,
+			*Result.ListAfterRemoveErrorMessage);
+	}
+
+	UE_LOG(
+		LogSQLUISamples,
+		Log,
+		TEXT("SQLUI sample smoke test %s clear %s. RemovedCount=%d ExpectedRemovedCount=%d"),
+		RepositoryName,
+		Result.bClearSucceeded ? TEXT("succeeded") : TEXT("failed"),
+		Result.ClearRemovedCount,
+		Result.ExpectedClearRemovedCount);
+
+	if (!Result.ClearErrorMessage.IsEmpty())
+	{
+		UE_LOG(
+			LogSQLUISamples,
+			Error,
+			TEXT("SQLUI sample smoke test %s clear error: %s"),
+			RepositoryName,
+			*Result.ClearErrorMessage);
+	}
+}
+
 void LogSQLUISampleSmokeTestRepositoryResult(
 	const FSQLUISampleSmokeTestResult& Result)
 {
@@ -169,6 +249,13 @@ void LogSQLUISampleSmokeTestRepositoryResult(
 	LogSQLUISampleSmokeTestRepositoryValidationMessages(
 		TEXT("load"),
 		Result.RepositoryLoadValidation);
+
+	if (Result.bRepositorySaveSucceeded)
+	{
+		LogSQLUISampleSmokeTestRepositoryOperationResult(
+			TEXT("in-memory layout repository"),
+			Result.RepositoryOperationSmoke);
+	}
 }
 
 void LogSQLUISampleSmokeTestJsonFileRepositoryResult(
@@ -210,6 +297,13 @@ void LogSQLUISampleSmokeTestJsonFileRepositoryResult(
 			Error,
 			TEXT("SQLUI sample smoke test JSON file layout repository load error: %s"),
 			*Result.JsonFileRepositoryLoadErrorMessage);
+	}
+
+	if (Result.bJsonFileRepositorySaveSucceeded)
+	{
+		LogSQLUISampleSmokeTestRepositoryOperationResult(
+			TEXT("JSON file layout repository"),
+			Result.JsonFileRepositoryOperationSmoke);
 	}
 }
 

--- a/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleSmokeTestRunner.cpp
+++ b/Plugins/SQLUI/Source/SQLUISamples/Private/SQLUISampleSmokeTestRunner.cpp
@@ -86,6 +86,7 @@ struct FSQLUISampleSmokeTestLayoutResult
 	FString RepositoryLoadErrorMessage;
 	FSQLUILayoutValidationResult RepositorySaveValidation;
 	FSQLUILayoutValidationResult RepositoryLoadValidation;
+	FSQLUISampleRepositoryOperationSmokeResult RepositoryOperationSmoke;
 	bool bUsedJsonFileLayoutRepository = false;
 	bool bJsonFileRepositorySaveSucceeded = false;
 	bool bJsonFileRepositoryLoadSucceeded = false;
@@ -95,6 +96,7 @@ struct FSQLUISampleSmokeTestLayoutResult
 	FString JsonFileRepositoryLoadErrorMessage;
 	FSQLUILayoutValidationResult JsonFileRepositorySaveValidation;
 	FSQLUILayoutValidationResult JsonFileRepositoryLoadValidation;
+	FSQLUISampleRepositoryOperationSmokeResult JsonFileRepositoryOperationSmoke;
 	TArray<FString> Warnings;
 	FSQLUILayoutDocument Document;
 };
@@ -253,6 +255,237 @@ FSQLUILayoutLoadResult LoadSQLUISampleLayoutFromRepository(
 	return LoadResult;
 }
 
+bool DoesSQLUISampleLayoutMetadataMatch(
+	const FSQLUILayoutMetadata& Candidate,
+	const FSQLUILayoutMetadata& Expected)
+{
+	return Candidate.LayoutId == Expected.LayoutId
+		&& Candidate.DisplayName == Expected.DisplayName
+		&& Candidate.Description == Expected.Description
+		&& Candidate.CreatedBy == Expected.CreatedBy;
+}
+
+bool DoesSQLUISampleLayoutMetadataListContain(
+	const TArray<FSQLUILayoutMetadata>& Layouts,
+	const FSQLUILayoutMetadata& Expected)
+{
+	for (const FSQLUILayoutMetadata& Layout : Layouts)
+	{
+		if (DoesSQLUISampleLayoutMetadataMatch(Layout, Expected))
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+FString MakeSQLUISampleRepositoryOperationError(
+	const TCHAR* RepositoryName,
+	const TCHAR* OperationName,
+	const FString& ErrorMessage)
+{
+	if (!ErrorMessage.IsEmpty())
+	{
+		return ErrorMessage;
+	}
+
+	return FString::Printf(
+		TEXT("SQLUI sample smoke test failed: %s %s failed."),
+		RepositoryName,
+		OperationName);
+}
+
+FString MakeSQLUISampleRepositoryMissingMetadataError(
+	const TCHAR* RepositoryName,
+	const FString& LayoutId)
+{
+	return FString::Printf(
+		TEXT("SQLUI sample smoke test failed: %s list after save did not include saved layout metadata for layout id '%s'."),
+		RepositoryName,
+		*LayoutId);
+}
+
+FString MakeSQLUISampleRepositoryUnexpectedMetadataError(
+	const TCHAR* RepositoryName,
+	const FString& LayoutId)
+{
+	return FString::Printf(
+		TEXT("SQLUI sample smoke test failed: %s list after remove still included layout metadata for layout id '%s'."),
+		RepositoryName,
+		*LayoutId);
+}
+
+FString MakeSQLUISampleRepositoryRemoveDidNotRemoveError(
+	const TCHAR* RepositoryName,
+	const FString& LayoutId,
+	const FString& ErrorMessage)
+{
+	if (!ErrorMessage.IsEmpty())
+	{
+		return ErrorMessage;
+	}
+
+	return FString::Printf(
+		TEXT("SQLUI sample smoke test failed: %s remove succeeded but did not remove layout id '%s'."),
+		RepositoryName,
+		*LayoutId);
+}
+
+FString MakeSQLUISampleRepositoryClearCountError(
+	const TCHAR* RepositoryName,
+	const int32 RemovedCount,
+	const int32 ExpectedRemovedCount)
+{
+	return FString::Printf(
+		TEXT("SQLUI sample smoke test failed: %s clear removed %d layout(s), expected %d."),
+		RepositoryName,
+		RemovedCount,
+		ExpectedRemovedCount);
+}
+
+bool DidSQLUISampleRepositoryOperationSmokeSucceed(
+	const FSQLUISampleRepositoryOperationSmokeResult& Result)
+{
+	return Result.bListAfterSaveSucceeded
+		&& Result.bSavedLayoutMetadataFound
+		&& Result.bRemoveSucceeded
+		&& Result.bSavedLayoutRemoved
+		&& Result.bListAfterRemoveSucceeded
+		&& Result.bRemovedLayoutMetadataAbsent
+		&& Result.bClearSucceeded;
+}
+
+template<typename LayoutRepositoryType>
+void RunSQLUISampleLayoutRepositorySmoke(
+	LayoutRepositoryType* Repository,
+	const TCHAR* RepositoryName,
+	const FSQLUILayoutDocument& Document,
+	FSQLUILayoutSaveResult& OutSaveResult,
+	FSQLUILayoutLoadResult& OutLoadResult,
+	FSQLUISampleRepositoryOperationSmokeResult& OutOperationResult)
+{
+	OutSaveResult = SaveSQLUISampleLayoutToRepository(
+		Repository,
+		RepositoryName,
+		Document);
+
+	const FString LayoutId = Document.Metadata.LayoutId;
+	if (!OutSaveResult.bSucceeded)
+	{
+		return;
+	}
+
+	const FSQLUILayoutRepositoryListResult ListAfterSaveResult = Repository->ListLayouts();
+	OutOperationResult.bListAfterSaveSucceeded = ListAfterSaveResult.bSucceeded;
+	OutOperationResult.ListAfterSaveLayoutCount = ListAfterSaveResult.Layouts.Num();
+	if (!ListAfterSaveResult.bSucceeded)
+	{
+		OutOperationResult.ListAfterSaveErrorMessage =
+			MakeSQLUISampleRepositoryOperationError(
+				RepositoryName,
+				TEXT("list after save"),
+				ListAfterSaveResult.ErrorMessage);
+	}
+	else
+	{
+		OutOperationResult.bSavedLayoutMetadataFound =
+			DoesSQLUISampleLayoutMetadataListContain(
+				ListAfterSaveResult.Layouts,
+				Document.Metadata);
+		if (!OutOperationResult.bSavedLayoutMetadataFound)
+		{
+			OutOperationResult.ListAfterSaveErrorMessage =
+				MakeSQLUISampleRepositoryMissingMetadataError(
+					RepositoryName,
+					LayoutId);
+		}
+	}
+
+	OutLoadResult = LoadSQLUISampleLayoutFromRepository(
+		Repository,
+		RepositoryName,
+		LayoutId);
+
+	const FSQLUILayoutRepositoryRemoveResult RemoveResult = Repository->RemoveLayout(LayoutId);
+	OutOperationResult.bRemoveSucceeded = RemoveResult.bSucceeded;
+	OutOperationResult.bSavedLayoutRemoved = RemoveResult.bRemoved;
+	if (!RemoveResult.bSucceeded)
+	{
+		OutOperationResult.RemoveErrorMessage =
+			MakeSQLUISampleRepositoryOperationError(
+				RepositoryName,
+				TEXT("remove"),
+				RemoveResult.ErrorMessage);
+	}
+	else if (!RemoveResult.bRemoved)
+	{
+		OutOperationResult.RemoveErrorMessage =
+			MakeSQLUISampleRepositoryRemoveDidNotRemoveError(
+				RepositoryName,
+				LayoutId,
+				RemoveResult.ErrorMessage);
+	}
+
+	const FSQLUILayoutRepositoryListResult ListAfterRemoveResult = Repository->ListLayouts();
+	OutOperationResult.bListAfterRemoveSucceeded = ListAfterRemoveResult.bSucceeded;
+	OutOperationResult.ListAfterRemoveLayoutCount = ListAfterRemoveResult.Layouts.Num();
+	if (!ListAfterRemoveResult.bSucceeded)
+	{
+		OutOperationResult.ListAfterRemoveErrorMessage =
+			MakeSQLUISampleRepositoryOperationError(
+				RepositoryName,
+				TEXT("list after remove"),
+				ListAfterRemoveResult.ErrorMessage);
+	}
+	else
+	{
+		OutOperationResult.bRemovedLayoutMetadataAbsent =
+			!DoesSQLUISampleLayoutMetadataListContain(
+				ListAfterRemoveResult.Layouts,
+				Document.Metadata);
+		if (!OutOperationResult.bRemovedLayoutMetadataAbsent)
+		{
+			OutOperationResult.ListAfterRemoveErrorMessage =
+				MakeSQLUISampleRepositoryUnexpectedMetadataError(
+					RepositoryName,
+					LayoutId);
+		}
+	}
+
+	OutOperationResult.ExpectedClearRemovedCount =
+		ListAfterRemoveResult.bSucceeded ? ListAfterRemoveResult.Layouts.Num() : 0;
+
+	const FSQLUILayoutRepositoryClearResult ClearResult = Repository->ClearLayouts();
+	OutOperationResult.ClearRemovedCount = ClearResult.RemovedCount;
+	if (!ClearResult.bSucceeded)
+	{
+		OutOperationResult.ClearErrorMessage =
+			MakeSQLUISampleRepositoryOperationError(
+				RepositoryName,
+				TEXT("clear"),
+				ClearResult.ErrorMessage);
+	}
+	else if (!ListAfterRemoveResult.bSucceeded)
+	{
+		OutOperationResult.ClearErrorMessage = FString::Printf(
+			TEXT("SQLUI sample smoke test failed: %s clear succeeded but RemovedCount could not be verified because list after remove failed."),
+			RepositoryName);
+	}
+	else if (ClearResult.RemovedCount != OutOperationResult.ExpectedClearRemovedCount)
+	{
+		OutOperationResult.ClearErrorMessage =
+			MakeSQLUISampleRepositoryClearCountError(
+				RepositoryName,
+				ClearResult.RemovedCount,
+				OutOperationResult.ExpectedClearRemovedCount);
+	}
+	else
+	{
+		OutOperationResult.bClearSucceeded = true;
+	}
+}
+
 FString MakeSQLUISampleJsonFileLayoutRepositoryBaseDirectory()
 {
 	FString BaseDirectory = FPaths::Combine(
@@ -262,19 +495,6 @@ FString MakeSQLUISampleJsonFileLayoutRepositoryBaseDirectory()
 		TEXT("Layouts"));
 	FPaths::NormalizeDirectoryName(BaseDirectory);
 	return BaseDirectory;
-}
-
-void AddSQLUISampleJsonFileRepositoryCleanupWarning(
-	FSQLUISampleSmokeTestLayoutResult& Result,
-	const FString& LayoutId,
-	const FString& BaseDirectory,
-	const FString& ErrorMessage)
-{
-	Result.Warnings.Add(FString::Printf(
-		TEXT("SQLUI sample smoke test JSON file layout repository cleanup did not remove layout id '%s' under '%s'. %s"),
-		*LayoutId,
-		*BaseDirectory,
-		*ErrorMessage));
 }
 
 FSQLUISampleSmokeTestLayoutResult ResolveSQLUISampleSmokeTestLayoutDocument(
@@ -314,11 +534,15 @@ FSQLUISampleSmokeTestLayoutResult ResolveSQLUISampleSmokeTestLayoutDocument(
 	{
 		USQLUIInMemoryLayoutRepository* LayoutRepository =
 			NewObject<USQLUIInMemoryLayoutRepository>(Outer);
-		const FSQLUILayoutSaveResult SaveResult =
-			SaveSQLUISampleLayoutToRepository(
-				LayoutRepository,
-				TEXT("in-memory layout repository"),
-				Result.Document);
+		FSQLUILayoutSaveResult SaveResult;
+		FSQLUILayoutLoadResult LoadResult;
+		RunSQLUISampleLayoutRepositorySmoke(
+			LayoutRepository,
+			TEXT("in-memory layout repository"),
+			Result.Document,
+			SaveResult,
+			LoadResult,
+			Result.RepositoryOperationSmoke);
 
 		Result.bRepositorySaveSucceeded = SaveResult.bSucceeded;
 		Result.SavedLayoutId = SaveResult.SavedLayoutId;
@@ -330,13 +554,6 @@ FSQLUISampleSmokeTestLayoutResult ResolveSQLUISampleSmokeTestLayoutDocument(
 			Result.bSucceeded = false;
 			return Result;
 		}
-
-		const FString LayoutId = Result.Document.Metadata.LayoutId;
-		const FSQLUILayoutLoadResult LoadResult =
-			LoadSQLUISampleLayoutFromRepository(
-				LayoutRepository,
-				TEXT("in-memory layout repository"),
-				LayoutId);
 
 		Result.bRepositoryLoadSucceeded =
 			LoadResult.bSucceeded && LoadResult.Validation.bIsValid;
@@ -355,6 +572,12 @@ FSQLUISampleSmokeTestLayoutResult ResolveSQLUISampleSmokeTestLayoutDocument(
 			return Result;
 		}
 
+		if (!DidSQLUISampleRepositoryOperationSmokeSucceed(Result.RepositoryOperationSmoke))
+		{
+			Result.bSucceeded = false;
+			return Result;
+		}
+
 		Result.Document = LoadResult.Document;
 	}
 
@@ -369,11 +592,15 @@ FSQLUISampleSmokeTestLayoutResult ResolveSQLUISampleSmokeTestLayoutDocument(
 			LayoutRepository->Configure(Settings);
 		}
 
-		const FSQLUILayoutSaveResult SaveResult =
-			SaveSQLUISampleLayoutToRepository(
-				LayoutRepository,
-				TEXT("JSON file layout repository"),
-				Result.Document);
+		FSQLUILayoutSaveResult SaveResult;
+		FSQLUILayoutLoadResult LoadResult;
+		RunSQLUISampleLayoutRepositorySmoke(
+			LayoutRepository,
+			TEXT("JSON file layout repository"),
+			Result.Document,
+			SaveResult,
+			LoadResult,
+			Result.JsonFileRepositoryOperationSmoke);
 
 		Result.bJsonFileRepositorySaveSucceeded = SaveResult.bSucceeded;
 		Result.JsonFileRepositorySavedLayoutId = SaveResult.SavedLayoutId;
@@ -386,38 +613,11 @@ FSQLUISampleSmokeTestLayoutResult ResolveSQLUISampleSmokeTestLayoutDocument(
 			return Result;
 		}
 
-		const FString LayoutId = Result.Document.Metadata.LayoutId;
-		const FSQLUILayoutLoadResult LoadResult =
-			LoadSQLUISampleLayoutFromRepository(
-				LayoutRepository,
-				TEXT("JSON file layout repository"),
-				LayoutId);
-
 		Result.bJsonFileRepositoryLoadSucceeded =
 			LoadResult.bSucceeded && LoadResult.Validation.bIsValid;
 		Result.JsonFileRepositoryLoadedLayoutId = LoadResult.Document.Metadata.LayoutId;
 		Result.JsonFileRepositoryLoadErrorMessage = LoadResult.ErrorMessage;
 		Result.JsonFileRepositoryLoadValidation = LoadResult.Validation;
-
-		const FString BaseDirectory = MakeSQLUISampleJsonFileLayoutRepositoryBaseDirectory();
-		const FSQLUILayoutRepositoryRemoveResult RemoveResult =
-			LayoutRepository->RemoveLayout(LayoutId);
-		if (!RemoveResult.bSucceeded)
-		{
-			AddSQLUISampleJsonFileRepositoryCleanupWarning(
-				Result,
-				LayoutId,
-				BaseDirectory,
-				RemoveResult.ErrorMessage);
-		}
-		else if (!RemoveResult.bRemoved)
-		{
-			AddSQLUISampleJsonFileRepositoryCleanupWarning(
-				Result,
-				LayoutId,
-				BaseDirectory,
-				RemoveResult.ErrorMessage);
-		}
 
 		if (!Result.bJsonFileRepositoryLoadSucceeded)
 		{
@@ -427,6 +627,12 @@ FSQLUISampleSmokeTestLayoutResult ResolveSQLUISampleSmokeTestLayoutDocument(
 				Result.JsonFileRepositoryLoadErrorMessage =
 					TEXT("SQLUI sample smoke test failed: JSON file layout repository loaded an invalid layout document.");
 			}
+			return Result;
+		}
+
+		if (!DidSQLUISampleRepositoryOperationSmokeSucceed(Result.JsonFileRepositoryOperationSmoke))
+		{
+			Result.bSucceeded = false;
 			return Result;
 		}
 
@@ -453,6 +659,7 @@ void ApplySQLUISampleLayoutResult(
 	Result.RepositoryLoadErrorMessage = LayoutResult.RepositoryLoadErrorMessage;
 	Result.RepositorySaveValidation = LayoutResult.RepositorySaveValidation;
 	Result.RepositoryLoadValidation = LayoutResult.RepositoryLoadValidation;
+	Result.RepositoryOperationSmoke = LayoutResult.RepositoryOperationSmoke;
 	Result.bUsedJsonFileLayoutRepository = LayoutResult.bUsedJsonFileLayoutRepository;
 	Result.bJsonFileRepositorySaveSucceeded = LayoutResult.bJsonFileRepositorySaveSucceeded;
 	Result.bJsonFileRepositoryLoadSucceeded = LayoutResult.bJsonFileRepositoryLoadSucceeded;
@@ -460,6 +667,7 @@ void ApplySQLUISampleLayoutResult(
 	Result.JsonFileRepositoryLoadedLayoutId = LayoutResult.JsonFileRepositoryLoadedLayoutId;
 	Result.JsonFileRepositorySaveErrorMessage = LayoutResult.JsonFileRepositorySaveErrorMessage;
 	Result.JsonFileRepositoryLoadErrorMessage = LayoutResult.JsonFileRepositoryLoadErrorMessage;
+	Result.JsonFileRepositoryOperationSmoke = LayoutResult.JsonFileRepositoryOperationSmoke;
 }
 
 void AddSQLUISampleLayoutValidationMessages(
@@ -475,6 +683,16 @@ void AddSQLUISampleLayoutValidationMessages(
 	{
 		Result.Warnings.Add(Warning);
 	}
+}
+
+void AddSQLUISampleRepositoryOperationMessages(
+	FSQLUISampleSmokeTestResult& Result,
+	const FSQLUISampleRepositoryOperationSmokeResult& OperationResult)
+{
+	AddSQLUISampleSmokeTestError(Result, OperationResult.ListAfterSaveErrorMessage);
+	AddSQLUISampleSmokeTestError(Result, OperationResult.RemoveErrorMessage);
+	AddSQLUISampleSmokeTestError(Result, OperationResult.ListAfterRemoveErrorMessage);
+	AddSQLUISampleSmokeTestError(Result, OperationResult.ClearErrorMessage);
 }
 
 FString MakeSQLUISampleLayoutFailureMessage(
@@ -500,6 +718,12 @@ FString MakeSQLUISampleLayoutFailureMessage(
 		return TEXT("SQLUI sample pipeline smoke test failed: in-memory layout repository load failed.");
 	}
 
+	if (LayoutResult.bUsedInMemoryLayoutRepository &&
+		!DidSQLUISampleRepositoryOperationSmokeSucceed(LayoutResult.RepositoryOperationSmoke))
+	{
+		return TEXT("SQLUI sample pipeline smoke test failed: in-memory layout repository operation smoke failed.");
+	}
+
 	if (LayoutResult.bUsedJsonFileLayoutRepository && !LayoutResult.bJsonFileRepositorySaveSucceeded)
 	{
 		return TEXT("SQLUI sample pipeline smoke test failed: JSON file layout repository save failed.");
@@ -508,6 +732,12 @@ FString MakeSQLUISampleLayoutFailureMessage(
 	if (LayoutResult.bUsedJsonFileLayoutRepository && !LayoutResult.bJsonFileRepositoryLoadSucceeded)
 	{
 		return TEXT("SQLUI sample pipeline smoke test failed: JSON file layout repository load failed.");
+	}
+
+	if (LayoutResult.bUsedJsonFileLayoutRepository &&
+		!DidSQLUISampleRepositoryOperationSmokeSucceed(LayoutResult.JsonFileRepositoryOperationSmoke))
+	{
+		return TEXT("SQLUI sample pipeline smoke test failed: JSON file layout repository operation smoke failed.");
 	}
 
 	return TEXT("SQLUI sample pipeline smoke test failed: layout document could not be resolved.");
@@ -572,6 +802,8 @@ FSQLUISampleSmokeTestResult USQLUISampleSmokeTestRunner::RunSmokeTest(
 		AddSQLUISampleSmokeTestError(Result, LayoutResult.RepositoryLoadErrorMessage);
 		AddSQLUISampleSmokeTestError(Result, LayoutResult.JsonFileRepositorySaveErrorMessage);
 		AddSQLUISampleSmokeTestError(Result, LayoutResult.JsonFileRepositoryLoadErrorMessage);
+		AddSQLUISampleRepositoryOperationMessages(Result, LayoutResult.RepositoryOperationSmoke);
+		AddSQLUISampleRepositoryOperationMessages(Result, LayoutResult.JsonFileRepositoryOperationSmoke);
 		Result.Warnings.Append(LayoutResult.Warnings);
 		return Result;
 	}

--- a/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISampleSmokeTestRunner.h
+++ b/Plugins/SQLUI/Source/SQLUISamples/Public/SQLUISampleSmokeTestRunner.h
@@ -11,6 +11,57 @@ class APlayerController;
 class USQLUIBaseWidget;
 
 USTRUCT(BlueprintType)
+struct SQLUISAMPLES_API FSQLUISampleRepositoryOperationSmokeResult
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bListAfterSaveSucceeded = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bSavedLayoutMetadataFound = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	int32 ListAfterSaveLayoutCount = 0;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FString ListAfterSaveErrorMessage;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bRemoveSucceeded = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bSavedLayoutRemoved = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FString RemoveErrorMessage;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bListAfterRemoveSucceeded = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bRemovedLayoutMetadataAbsent = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	int32 ListAfterRemoveLayoutCount = 0;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FString ListAfterRemoveErrorMessage;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	bool bClearSucceeded = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	int32 ClearRemovedCount = 0;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	int32 ExpectedClearRemovedCount = 0;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FString ClearErrorMessage;
+};
+
+USTRUCT(BlueprintType)
 struct SQLUISAMPLES_API FSQLUISampleSmokeTestRequest
 {
 	GENERATED_BODY()
@@ -100,6 +151,9 @@ struct SQLUISAMPLES_API FSQLUISampleSmokeTestResult
 	FSQLUILayoutValidationResult RepositoryLoadValidation;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FSQLUISampleRepositoryOperationSmokeResult RepositoryOperationSmoke;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
 	bool bUsedJsonFileLayoutRepository = false;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
@@ -119,6 +173,9 @@ struct SQLUISAMPLES_API FSQLUISampleSmokeTestResult
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
 	FString JsonFileRepositoryLoadErrorMessage;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
+	FSQLUISampleRepositoryOperationSmokeResult JsonFileRepositoryOperationSmoke;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SQLUI|Samples")
 	TArray<FString> Errors;

--- a/docs/sqlui_smoke_test.md
+++ b/docs/sqlui_smoke_test.md
@@ -4,13 +4,13 @@ The SQLUI sample smoke test commandlet runs the current sample runtime widget pi
 
 By default, the smoke test uses the existing in-memory C++ layout document. It can also run the built-in SQLUISamples JSON layout fixture, which deserializes a tiny `SQLUI.FilterBox` layout through SQLUICore's layout JSON helpers before running the same runtime widget pipeline.
 
-The in-memory repository smoke path reuses that same JSON fixture, saves the deserialized layout into `USQLUIInMemoryLayoutRepository`, loads it back by layout id, and then runs the runtime widget pipeline with the loaded document.
+The in-memory repository smoke path reuses that same JSON fixture, saves the deserialized layout into `USQLUIInMemoryLayoutRepository`, verifies `ListLayouts` includes the saved metadata, loads it back by layout id, verifies `RemoveLayout` removes it, verifies `ListLayouts` no longer includes it, exercises `ClearLayouts`, and then runs the runtime widget pipeline with the loaded document.
 
-The JSON file repository smoke path also reuses the JSON fixture, saves the deserialized layout into `USQLUIJsonFileLayoutRepository`, loads it back by layout id, and then runs the runtime widget pipeline with the loaded document.
+The JSON file repository smoke path also reuses the JSON fixture, saves the deserialized layout into `USQLUIJsonFileLayoutRepository`, verifies `ListLayouts` includes the saved metadata, loads it back by layout id, verifies `RemoveLayout` removes it, verifies `ListLayouts` no longer includes it, exercises `ClearLayouts`, and then runs the runtime widget pipeline with the loaded document.
 
 This is a local developer workflow only. It is not CI yet, and it does not assume Unreal Engine is installed on GitHub Actions or any build agent.
 
-The smoke test does not edit maps, levels, Content, SQLite databases, or the viewport. It does not add database behavior, use SQLite, or attach widgets to the viewport. The JSON file repository smoke path writes only under `Saved\SQLUI\SmokeTests\Layouts` and attempts to remove its test layout after loading it.
+The smoke test does not edit maps, levels, Content, SQLite databases, or the viewport. It does not add database behavior, use SQLite, or attach widgets to the viewport. The JSON file repository smoke path writes only under `Saved\SQLUI\SmokeTests\Layouts`, removes its saved layout after loading it, and clears remaining layouts in that smoke-test repository directory.
 
 ## Build JerryRiggedEditor
 
@@ -64,7 +64,7 @@ The commandlet also accepts `-JsonLayoutFixture` directly as an alias when invok
 
 ## Run The In-Memory Repository Smoke Test
 
-The in-memory repository path keeps the same transient commandlet flow, deserializes the built-in SQLUISamples JSON layout fixture, saves it into `USQLUIInMemoryLayoutRepository`, loads it back by `LayoutId`, and runs the same runtime widget pipeline with the loaded layout document:
+The in-memory repository path keeps the same transient commandlet flow, deserializes the built-in SQLUISamples JSON layout fixture, saves it into `USQLUIInMemoryLayoutRepository`, verifies list-after-save, loads it back by `LayoutId`, checks remove/list-after-remove/clear repository operations, and runs the same runtime widget pipeline with the loaded layout document:
 
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\RunSQLUISmokeTest.ps1 -EngineRoot "C:\Program Files\Epic Games\UE_5.7" -UseInMemoryLayoutRepository
@@ -76,7 +76,7 @@ This path is still sample scaffolding only. It does not use SQLite, disk persist
 
 ## Run The JSON File Repository Smoke Test
 
-The JSON file repository path keeps the same transient commandlet flow, deserializes the built-in SQLUISamples JSON layout fixture, saves it into `USQLUIJsonFileLayoutRepository`, loads it back by `LayoutId`, and runs the same runtime widget pipeline with the loaded layout document:
+The JSON file repository path keeps the same transient commandlet flow, deserializes the built-in SQLUISamples JSON layout fixture, saves it into `USQLUIJsonFileLayoutRepository`, verifies list-after-save, loads it back by `LayoutId`, checks remove/list-after-remove/clear repository operations, and runs the same runtime widget pipeline with the loaded layout document:
 
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\RunSQLUISmokeTest.ps1 -EngineRoot "C:\Program Files\Epic Games\UE_5.7" -UseJsonFileLayoutRepository
@@ -84,7 +84,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\RunSQLUISmokeTest.
 
 The commandlet also accepts `-JsonFileLayoutRepository` directly as an alias when invoking `UnrealEditor-Cmd.exe`.
 
-This path is still sample scaffolding only. It does not use SQLite, Content, maps, or viewport attachment. It writes the temporary layout file under `Saved\SQLUI\SmokeTests\Layouts` and attempts to remove it after the load step. If cleanup cannot remove the file, the warning log names that Saved path.
+This path is still sample scaffolding only. It does not use SQLite, Content, maps, or viewport attachment. It writes temporary layout files under `Saved\SQLUI\SmokeTests\Layouts`, removes the saved fixture layout after the load step, and verifies `ClearLayouts` removes the same number of remaining layouts reported by the post-remove list.
 
 ## Expected Results
 
@@ -120,6 +120,10 @@ SQLUI sample smoke test JSON fixture validation succeeded.
 SQLUI sample smoke test in-memory layout repository selected.
 SQLUI sample smoke test in-memory layout repository save succeeded.
 SQLUI sample smoke test in-memory layout repository load succeeded.
+SQLUI sample smoke test in-memory layout repository list after save succeeded. LayoutCount=1 MetadataFound=true
+SQLUI sample smoke test in-memory layout repository remove succeeded. Removed=true
+SQLUI sample smoke test in-memory layout repository list after remove succeeded. LayoutCount=0 MetadataAbsent=true
+SQLUI sample smoke test in-memory layout repository clear succeeded. RemovedCount=0 ExpectedRemovedCount=0
 SQLUI sample smoke test commandlet succeeded.
 SQLUI sample smoke test root widget valid: true
 SQLUI sample smoke test created widget count: 1
@@ -134,10 +138,16 @@ SQLUI sample smoke test JSON fixture validation succeeded.
 SQLUI sample smoke test JSON file layout repository selected.
 SQLUI sample smoke test JSON file layout repository save succeeded.
 SQLUI sample smoke test JSON file layout repository load succeeded.
+SQLUI sample smoke test JSON file layout repository list after save succeeded. LayoutCount=1 MetadataFound=true
+SQLUI sample smoke test JSON file layout repository remove succeeded. Removed=true
+SQLUI sample smoke test JSON file layout repository list after remove succeeded. LayoutCount=0 MetadataAbsent=true
+SQLUI sample smoke test JSON file layout repository clear succeeded. RemovedCount=0 ExpectedRemovedCount=0
 SQLUI sample smoke test commandlet succeeded.
 SQLUI sample smoke test root widget valid: true
 SQLUI sample smoke test created widget count: 1
 ```
+
+If the JSON file repository smoke directory already contains valid layout files, the listed counts can be higher; the clear step still expects `RemovedCount` to match the post-remove list count.
 
 Some optional pipeline steps may log `Skipped` depending on the current sample request. Failures are logged with `SQLUI sample smoke test commandlet failed.` and the script returns a non-zero exit code.
 


### PR DESCRIPTION
## Summary

- Adds list/remove/clear smoke coverage for the in-memory repository path.
- Adds list/remove/clear smoke coverage for the JSON-file repository path.
- Keeps SQLite, Content assets, maps, editor tooling, and CI out of scope.

## Validation

- `git diff --check main...HEAD`
- Built `JerryRiggedEditor Win64 Development`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\RunSQLUISmokeTest.ps1 -EngineRoot "C:\Program Files\Epic Games\UE_5.7" -UseInMemoryLayoutRepository`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\RunSQLUISmokeTest.ps1 -EngineRoot "C:\Program Files\Epic Games\UE_5.7" -UseJsonFileLayoutRepository`